### PR TITLE
fix(hooks): reviews 3+4 — Windows installs, reinfection, and a false no-network claim

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:routing:models": "npm run build && node scripts/prism-infer-live-test.mjs --infer",
     "test:mcp": "node ./test_cross_mcp.js",
     "import": "node dist/utils/universalImporter.js",
-    "postinstall": "node dist/postinstall.js >/dev/null 2>&1 || true"
+    "postinstall": "node -e \"import('./dist/postinstall.js').catch(()=>{})\""
   },
   "keywords": [
     "mcp-server",

--- a/scripts/dev/browse.py
+++ b/scripts/dev/browse.py
@@ -1249,6 +1249,37 @@ def cmd_open(session, url):
     return result
 
 
+def _enforce_max_edge(path, max_edge):
+    """Downscale an image in place so its longest edge is <= max_edge.
+
+    Returns a warning string when the image remains oversized (no scaler
+    available), else None. Never raises: a failed downscale must not turn a
+    real capture into a failure — but it must not stay silent either.
+    """
+    try:
+        import shutil as _shutil, subprocess as _subprocess
+        if _shutil.which("sips"):
+            _subprocess.run(["sips", "-Z", str(max_edge), str(path)],
+                            capture_output=True, timeout=30, check=True)
+            return None
+        try:
+            from PIL import Image  # type: ignore
+            with Image.open(path) as im:
+                w, h = im.size
+                if max(w, h) <= max_edge:
+                    return None
+                scale = max_edge / max(w, h)
+                im.resize((int(w * scale), int(h * scale))).save(path)
+            return None
+        except ImportError:
+            pass
+        return (f"image may exceed {max_edge}px and no scaler is available "
+                f"(sips/Pillow) — large images poison Claude image attach "
+                f"after ~20 images per conversation")
+    except Exception as error:  # noqa: BLE001 — never fail a capture on scaling
+        return f"downscale failed ({error}); image may exceed {max_edge}px"
+
+
 def cmd_screenshot(session, output=None, cleanup=False, full_page=True, selector=None):
     """Capture a screenshot and validate that it is not an empty frame."""
     session.screenshot_counter += 1
@@ -1269,6 +1300,18 @@ def cmd_screenshot(session, output=None, cleanup=False, full_page=True, selector
     else:
         session.page.screenshot(path=str(path), full_page=full_page)
 
+    # ── Anthropic many-image rule (learned live, 2026-08-13) ─────────────
+    # Past ~20 images in a conversation, the API caps every image at 2000px
+    # per dimension and re-validates the WHOLE history on each request. One
+    # oversized capture early in a session poisons every later attach — the
+    # agent that must LOOK at screenshots loses the ability to see them,
+    # mid-conversation, permanently. Full-page captures routinely exceed
+    # 2000px in height, so every capture is normalized to a 1900px long edge
+    # here, at the source. sips is macOS-only; elsewhere we fall back to
+    # Pillow if present and otherwise WARN LOUDLY rather than emit poison
+    # silently.
+    _downscale_warning = _enforce_max_edge(path, 1900)
+
     size = path.stat().st_size
     audit_log("screenshot", str(path), f"size={size},ephemeral={cleanup}")
     result = {
@@ -1281,6 +1324,8 @@ def cmd_screenshot(session, output=None, cleanup=False, full_page=True, selector
     # A blank or error frame must not report success: a screenshot is evidence
     # only if something actually rendered.
     warnings = []
+    if _downscale_warning:
+        warnings.append(_downscale_warning)
     if size < MIN_SCREENSHOT_BYTES:
         result["status"] = "failed"
         warnings.append(f"image is {size} bytes, below the {MIN_SCREENSHOT_BYTES}-byte floor")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -231,7 +231,7 @@ program
       if (options.selfUpdate !== false && !options.dryRun) {
         const { maybeSelfUpdate } = await import('./selfUpdate.js');
         const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
-        const upd = maybeSelfUpdate({ currentVersion: pkg.version, log: (l) => console.log(l) });
+        const upd = maybeSelfUpdate({ currentVersion: pkg.version, invokedFrom: process.argv[1], log: (l) => console.log(l) });
         if (upd.action === 'updated') {
           console.log(`✓ prism updated to ${upd.latest}; re-running connect with the new version`);
           const rerun = spawnSync(process.execPath, [process.argv[1], 'connect', ...process.argv.slice(3), '--no-self-update'], { stdio: 'inherit' });
@@ -356,10 +356,17 @@ program
                 const { ensurePromptRouteHook } = await import('./promptRouteHostHook.js');
                 for (const r of ensurePromptRouteHook({ hosts: hookHosts, mode: 'explicit' })) {
                   const state = r.script === 'unchanged' && r.config === 'unchanged' ? 'up to date' : 'installed';
-                  if (r.host === 'codex' && r.codexApproval !== 'detected') {
+                  if (r.host === 'codex' && r.codexApproval === 'pending-or-unknown') {
                     // Codex silently skips untrusted hooks — a green "installed"
                     // here would be the "configured and inert" lie.
                     console.log(`⚠ codex: prism-route hook ${state}, AWAITING TRUST — run codex, then /hooks, and trust the entry ending prism-route/on_prompt.py`);
+                  } else if (r.host === 'codex' && r.codexApproval === 'state-present-unverifiable') {
+                    // Approvals are keyed by definition hash, whose algorithm is
+                    // not public — once ANY trust state exists we cannot tell
+                    // ours apart from here. Say exactly that; asserting AWAITING
+                    // after the operator pressed t reads as "the trust didn't
+                    // take", which is a false alarm against their own action.
+                    console.log(`− codex: prism-route hook ${state}; trust state exists but is not verifiable from here — confirm once in /hooks`);
                   } else {
                     console.log(`✓ ${r.host}: prism-route prompt hook ${state} (${r.scriptPath})`);
                   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { SqliteStorage } from './storage/sqlite.js';
 import { handleVerifyStatus, handleGenerateHarness } from './verification/cliHandler.js';
 import * as path from 'path';
@@ -217,8 +219,29 @@ program
   .option('--all', 'Target all supported hosts instead of auto-detecting installed hosts')
   .option('--dry-run', 'Preview configuration changes without writing files')
   .option('--refresh', 'Refresh only entries previously created by Prism; custom entries stay untouched')
-  .action(async (options: { host?: string; all?: boolean; dryRun?: boolean; refresh?: boolean }) => {
+  .option('--no-self-update', 'Skip the npm self-update check; configure with the currently installed version')
+  .action(async (options: { host?: string; all?: boolean; dryRun?: boolean; refresh?: boolean; selfUpdate?: boolean }) => {
     try {
+      // ── Converge the PACKAGE first, then the configs ──────────────
+      // connect is the one command the operator runs to make a machine
+      // current; leaving it configuring with stale code produced the
+      // "fresh hook, stale CLI" state observed live on 2026-08-13. After a
+      // successful update we RE-EXEC the new binary so the remainder of
+      // connect runs the code it just installed. Dry runs never update.
+      if (options.selfUpdate !== false && !options.dryRun) {
+        const { maybeSelfUpdate } = await import('./selfUpdate.js');
+        const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+        const upd = maybeSelfUpdate({ currentVersion: pkg.version, log: (l) => console.log(l) });
+        if (upd.action === 'updated') {
+          console.log(`✓ prism updated to ${upd.latest}; re-running connect with the new version`);
+          const rerun = spawnSync(process.execPath, [process.argv[1], 'connect', ...process.argv.slice(3), '--no-self-update'], { stdio: 'inherit' });
+          process.exit(rerun.status ?? 0);
+        } else if (upd.action === 'failed') {
+          console.log(`⚠ self-update: ${upd.detail}`);
+        } else if (upd.action === 'skipped') {
+          console.log(`− self-update skipped: ${upd.detail}`);
+        }
+      }
       if (!options.dryRun) {
         console.log('Close target MCP hosts before registration so they cannot edit configuration concurrently.');
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -333,7 +333,13 @@ program
                 const { ensurePromptRouteHook } = await import('./promptRouteHostHook.js');
                 for (const r of ensurePromptRouteHook({ hosts: hookHosts, mode: 'explicit' })) {
                   const state = r.script === 'unchanged' && r.config === 'unchanged' ? 'up to date' : 'installed';
-                  console.log(`✓ ${r.host}: prism-route prompt hook ${state} (${r.scriptPath})`);
+                  if (r.host === 'codex' && r.codexApproval !== 'detected') {
+                    // Codex silently skips untrusted hooks — a green "installed"
+                    // here would be the "configured and inert" lie.
+                    console.log(`⚠ codex: prism-route hook ${state}, AWAITING TRUST — run codex, then /hooks, and trust the entry ending prism-route/on_prompt.py`);
+                  } else {
+                    console.log(`✓ ${r.host}: prism-route prompt hook ${state} (${r.scriptPath})`);
+                  }
                 }
               } catch {
                 console.error('⚠ prism-route hook installation failed — skills still route at session start');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -458,7 +458,9 @@ program
     try {
       const chunks: Buffer[] = [];
       for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-      const prompt = Buffer.concat(chunks).toString('utf8');
+      // A pasted log can be megabytes; triggers live in the first human-sized
+      // stretch of a prompt, and unbounded input is regex food.
+      const prompt = Buffer.concat(chunks).toString('utf8').slice(0, 100_000);
       const loaded = (options.loaded ?? '')
         .split(',')
         .map((n) => n.trim())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,8 @@
 
 import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdirSync, readdirSync, statSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { SqliteStorage } from './storage/sqlite.js';
 import { handleVerifyStatus, handleGenerateHarness } from './verification/cliHandler.js';
 import * as path from 'path';
@@ -486,6 +487,31 @@ program
 // Claude Code and Codex, so the contract is: always exit 0, always print one
 // JSON object, and stay off the network (cached settings DB only). A hook
 // that can fail a turn gets uninstalled; a hook that is slow gets noticed.
+
+/** Deliberate offload for payloads over the host inline cap. The host's own
+ *  overflow path swaps the payload for a 2KB preview with no instruction to
+ *  read the rest; this file plus the inline pointer is the recoverable form. */
+function writeRouteOffload(fullText: string): string | undefined {
+  try {
+    const dir = path.join(homedir(), '.prism-mcp', 'route-context');
+    mkdirSync(dir, { recursive: true });
+    try {
+      // Best-effort prune: one file per over-budget routed prompt, kept a week.
+      for (const f of readdirSync(dir)) {
+        const p = path.join(dir, f);
+        try {
+          if (Date.now() - statSync(p).mtimeMs > 7 * 86_400_000) rmSync(p);
+        } catch { /* skip unstat-able entries */ }
+      }
+    } catch { /* prune failure never blocks the write */ }
+    const target = path.join(dir, `route-${Date.now()}-${process.pid}.md`);
+    writeFileSync(target, fullText);
+    return target;
+  } catch {
+    return undefined; // reshape degrades to the loud in-band fallback
+  }
+}
+
 program
   .command('route-prompt')
   .description('Match a prompt (stdin) against skill triggers; prints {names, text} JSON. Used by the prism-route host hook.')
@@ -502,8 +528,15 @@ program
         .map((n) => n.trim())
         .filter(Boolean);
       const { runPromptRouteFromCache } = await import('./tools/ledgerHandlers.js');
+      const { reshapeForInlineBudget, HOOK_INLINE_SAFE_CHARS } = await import('./tools/promptRouteHandler.js');
       const result = await runPromptRouteFromCache(prompt, loaded);
-      const payload = JSON.stringify({ names: result.names, text: result.names.length > 0 ? result.text : '' });
+      // The hook path must fit the host's inline cap; the MCP tool path
+      // (session_route_prompt) keeps the full 30k — tool results inline far
+      // higher than hook context does.
+      const shaped = result.names.length > 0
+        ? reshapeForInlineBudget(result, HOOK_INLINE_SAFE_CHARS, writeRouteOffload)
+        : { text: '' };
+      const payload = JSON.stringify({ names: result.names, text: result.names.length > 0 ? shaped.text : '' });
       await new Promise<void>((resolveWrite) => process.stdout.write(payload + '\n', () => resolveWrite()));
     } catch {
       // Never break the hook: an empty result is a routing miss, not an error.

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -12,6 +12,20 @@ try {
   if (process.env.PRISM_DEBUG) {
     for (const r of results) console.error(`[prism postinstall] ${r.host}: script=${r.script} config=${r.config}`);
   }
+  // The ONE step install cannot do for the operator, said at the only moment
+  // they are certainly watching. Codex's hook-trust gate exists so software
+  // cannot approve its own execution — prism will never write that trust
+  // state (a compromised release would otherwise gain silent
+  // execute-on-every-prompt), so the honest maximum is to make the pending
+  // approval impossible to miss. Approval is per hook-version, not per
+  // release: it recurs only when the hook script itself changes.
+  const codex = results.find((r) => r.host === "codex");
+  if (codex && codex.codexApproval !== "detected") {
+    console.error(
+      "\n[prism] Codex hook installed but NOT yet trusted — Codex silently skips it until you approve it once:\n" +
+      "[prism]   codex  ->  /hooks  ->  entry ending prism-route/on_prompt.py  ->  press t\n",
+    );
+  }
 } catch {
   /* never fail an install */
 }

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -20,7 +20,7 @@ try {
   // approval impossible to miss. Approval is per hook-version, not per
   // release: it recurs only when the hook script itself changes.
   const codex = results.find((r) => r.host === "codex");
-  if (codex && codex.codexApproval !== "detected") {
+  if (codex && codex.codexApproval === "pending-or-unknown") {
     console.error(
       "\n[prism] Codex hook installed but NOT yet trusted — Codex silently skips it until you approve it once:\n" +
       "[prism]   codex  ->  /hooks  ->  entry ending prism-route/on_prompt.py  ->  press t\n",

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -330,10 +330,16 @@ function ensureScript(hookDir: string): "installed" | "refreshed" | "unchanged" 
 function ensureRegistered(configPath: string, scriptPath: string, host: "claude" | "codex"): "registered" | "updated" | "unchanged" {
   // Codex truncates hook additionalContext at ~2,500 tokens by default —
   // a head-and-tail preview of our payload, which defeats the injection.
-  // additionalContextLimit: 0 passes the full context through; the payload is
-  // already bounded by HOOK_INLINE_SAFE_CHARS on the emitting side, so the
-  // pass-through is not unbounded. Claude Code has no such field (its 10k-char
-  // cap is not configurable) — never write unknown keys into settings.json.
+  // additionalContextLimit: 0 passes the full context through — per the Codex
+  // hooks reference (learn.chatgpt.com/docs/hooks, verified 2026-08-13):
+  // "Setting to 0 passes full context directly to the model". NOT an in-repo
+  // guarantee: if Codex ever re-reads 0 as a literal zero cap, injection dies
+  // silently there — re-verify with a live codex probe after any Codex
+  // upgrade. The payload is already bounded by HOOK_INLINE_SAFE_CHARS on the
+  // emitting side, so the pass-through is not unbounded. Claude Code has no
+  // such field (its 10k-char cap is not configurable) — never write unknown
+  // keys into settings.json (a manually-added stray field there is left
+  // alone, not stripped).
   const wantsLimit = host === "codex";
   let config: Record<string, unknown> = {};
   let originalText: string | undefined;

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -29,7 +29,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 /** Bump to force the on-disk script to be rewritten on the next ensure. */
-export const PROMPT_ROUTE_HOOK_VERSION = "2";
+export const PROMPT_ROUTE_HOOK_VERSION = "3";
 
 const MARKER_FILE = ".prism-managed.json";
 const SCRIPT_FILE = "on_prompt.py";
@@ -112,6 +112,9 @@ def main():
     if len(prompt) < 6 or prompt.startswith("/"):
         emit()
         return
+    # A pasted log can be megabytes; triggers live in the first human-sized
+    # stretch, and the CLI caps identically on its side.
+    prompt = prompt[:100_000]
 
     session = str(
         payload.get("session_id")
@@ -152,9 +155,19 @@ def main():
         emit()
         return
 
-    try:
-        data = json.loads(result.stdout.strip() or "{}")
-    except Exception:
+    # Parse the LAST line that is JSON: wrappers hooked into node via
+    # NODE_OPTIONS (dotenv banners and the like) print to stdout BEFORE the
+    # CLI's own output, and one polluted line must not kill routing.
+    data = None
+    for line in reversed(result.stdout.strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                data = json.loads(line)
+                break
+            except Exception:
+                continue
+    if not isinstance(data, dict):
         emit()
         return
     names = [n for n in (data.get("names") or []) if isinstance(n, str)]

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -327,7 +327,14 @@ function ensureScript(hookDir: string): "installed" | "refreshed" | "unchanged" 
   return scriptExists ? "refreshed" : "installed";
 }
 
-function ensureRegistered(configPath: string, scriptPath: string): "registered" | "updated" | "unchanged" {
+function ensureRegistered(configPath: string, scriptPath: string, host: "claude" | "codex"): "registered" | "updated" | "unchanged" {
+  // Codex truncates hook additionalContext at ~2,500 tokens by default —
+  // a head-and-tail preview of our payload, which defeats the injection.
+  // additionalContextLimit: 0 passes the full context through; the payload is
+  // already bounded by HOOK_INLINE_SAFE_CHARS on the emitting side, so the
+  // pass-through is not unbounded. Claude Code has no such field (its 10k-char
+  // cap is not configurable) — never write unknown keys into settings.json.
+  const wantsLimit = host === "codex";
   let config: Record<string, unknown> = {};
   let originalText: string | undefined;
   try {
@@ -358,18 +365,20 @@ function ensureRegistered(configPath: string, scriptPath: string): "registered" 
       // would re-register a duplicate entry.
       const command = String((h as { command?: unknown }).command ?? "");
       if (!command.replace(/\\/g, "/").includes(COMMAND_SIGNATURE)) continue;
-      if (command === wanted) return "unchanged";
-      // Same hook, older version: UPDATE the definition in place. This is
-      // what makes a script refresh visible to Codex's definition-hash —
-      // and on Claude it is a harmless argv change.
+      const limitCurrent = !wantsLimit || (h as { additionalContextLimit?: unknown }).additionalContextLimit === 0;
+      if (command === wanted && limitCurrent) return "unchanged";
+      // Same hook, older definition: UPDATE it in place. This is what makes a
+      // refresh visible to Codex's definition-hash — and on Claude it is a
+      // harmless argv change.
       (h as { command: string }).command = wanted;
+      if (wantsLimit) (h as { additionalContextLimit?: number }).additionalContextLimit = 0;
       stale = true;
     }
   }
   if (!stale) {
     entries.push({
       matcher: "*",
-      hooks: [{ type: "command", command: wanted, timeout: 15 }],
+      hooks: [{ type: "command", command: wanted, timeout: 15, ...(wantsLimit ? { additionalContextLimit: 0 } : {}) }],
     });
   }
   hooks.UserPromptSubmit = entries;
@@ -397,7 +406,7 @@ export function ensurePromptRouteHook(options: EnsureHookOptions = {}): EnsureHo
       const hookDir = join(spec.root, "hooks", HOOK_DIR);
       const script = ensureScript(hookDir);
       if (script === "disabled") continue; // operator opt-out — do not re-register either
-      const config = ensureRegistered(spec.configPath, join(hookDir, SCRIPT_FILE));
+      const config = ensureRegistered(spec.configPath, join(hookDir, SCRIPT_FILE), spec.host);
       const result: EnsureHookHostResult = { host: spec.host, script, config, scriptPath: join(hookDir, SCRIPT_FILE), configPath: spec.configPath };
       if (spec.host === "codex") {
         // Never report a green "registered" as if it were active: Codex

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -36,6 +36,20 @@ const SCRIPT_FILE = "on_prompt.py";
 const HOOK_DIR = "prism-route";
 /** Substring that identifies our entry inside a host hooks config. */
 const COMMAND_SIGNATURE = `${HOOK_DIR}/${SCRIPT_FILE}`;
+/**
+ * The command registered in the host config carries the version as an
+ * argument (the script ignores argv — it reads stdin). This is a SECURITY
+ * property, found by an external probe of Codex 0.146: Codex's hook-trust
+ * hash covers the CONFIGURED DEFINITION, not the file the command points at.
+ * With a stable command and a version-refreshed script, every prism upgrade
+ * would silently swap the executable content behind an already-trusted hash —
+ * exactly what the trust gate exists to prevent. Versioning the command
+ * changes the definition on every script change, forcing Codex to re-prompt.
+ * Cost: one approval per release, which is Codex's consent model working.
+ */
+function hookCommand(scriptPath: string): string {
+  return `python3 ${scriptPath} --v${PROMPT_ROUTE_HOOK_VERSION}`;
+}
 
 /**
  * The hook script. Python because both hosts' existing hook fleets are
@@ -198,7 +212,11 @@ if __name__ == "__main__":
 export interface EnsureHookHostResult {
   host: "claude" | "codex";
   script: "installed" | "refreshed" | "unchanged" | "disabled";
-  config: "registered" | "unchanged";
+  config: "registered" | "updated" | "unchanged";
+  /** Codex only: its trust gate silently skips unapproved hooks. We can
+   *  DETECT approval only coarsely (a [hooks.state] section naming our hook);
+   *  "pending-or-unknown" means the operator must run /hooks and trust it. */
+  codexApproval?: "detected" | "pending-or-unknown";
   scriptPath: string;
   configPath: string;
 }
@@ -253,6 +271,21 @@ function hostSpecs(homeDir: string, env: NodeJS.ProcessEnv): HostSpec[] {
   ];
 }
 
+/**
+ * Coarse Codex approval detection. Codex persists hook approvals as a
+ * [hooks.state] table in config.toml keyed by definition hash; the hashing
+ * algorithm is not public, so the only honest signals are "a state section
+ * exists and mentions our hook path" (detected) or anything else
+ * (pending-or-unknown). Never treat unknown as approved.
+ */
+function detectCodexApproval(codexRoot: string): "detected" | "pending-or-unknown" {
+  try {
+    const toml = readFileSync(join(codexRoot, "config.toml"), "utf8");
+    if (/\[hooks\.state/.test(toml) && toml.includes(COMMAND_SIGNATURE)) return "detected";
+  } catch { /* unreadable = unknown */ }
+  return "pending-or-unknown";
+}
+
 function writeAtomically(path: string, content: string): void {
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.prism-tmp-${process.pid}`;
@@ -288,7 +321,7 @@ function ensureScript(hookDir: string): "installed" | "refreshed" | "unchanged" 
   return scriptExists ? "refreshed" : "installed";
 }
 
-function ensureRegistered(configPath: string, scriptPath: string): "registered" | "unchanged" {
+function ensureRegistered(configPath: string, scriptPath: string): "registered" | "updated" | "unchanged" {
   let config: Record<string, unknown> = {};
   let originalText: string | undefined;
   try {
@@ -306,29 +339,37 @@ function ensureRegistered(configPath: string, scriptPath: string): "registered" 
     : {}) as Record<string, unknown>;
   const entries = Array.isArray(hooks.UserPromptSubmit) ? (hooks.UserPromptSubmit as unknown[]) : [];
 
-  const present = entries.some((entry) => {
-    if (!entry || typeof entry !== "object") return false;
+  const wanted = hookCommand(scriptPath);
+  let stale = false;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
     const inner = (entry as { hooks?: unknown }).hooks;
-    if (!Array.isArray(inner)) return false;
-    return inner.some((h) => {
-      if (!h || typeof h !== "object") return false;
+    if (!Array.isArray(inner)) continue;
+    for (const h of inner) {
+      if (!h || typeof h !== "object") continue;
       // Normalize separators: on Windows join() registers a backslash path,
       // and a forward-slash signature would never match — so every ensure
       // would re-register a duplicate entry.
-      const command = String((h as { command?: unknown }).command ?? "").replace(/\\/g, "/");
-      return command.includes(COMMAND_SIGNATURE);
+      const command = String((h as { command?: unknown }).command ?? "");
+      if (!command.replace(/\\/g, "/").includes(COMMAND_SIGNATURE)) continue;
+      if (command === wanted) return "unchanged";
+      // Same hook, older version: UPDATE the definition in place. This is
+      // what makes a script refresh visible to Codex's definition-hash —
+      // and on Claude it is a harmless argv change.
+      (h as { command: string }).command = wanted;
+      stale = true;
+    }
+  }
+  if (!stale) {
+    entries.push({
+      matcher: "*",
+      hooks: [{ type: "command", command: wanted, timeout: 15 }],
     });
-  });
-  if (present) return "unchanged";
-
-  entries.push({
-    matcher: "*",
-    hooks: [{ type: "command", command: `python3 ${scriptPath}`, timeout: 15 }],
-  });
+  }
   hooks.UserPromptSubmit = entries;
   config.hooks = hooks;
   writeAtomically(configPath, `${JSON.stringify(config, null, 2)}\n`);
-  return "registered";
+  return stale ? "updated" : "registered";
 }
 
 /**
@@ -351,7 +392,14 @@ export function ensurePromptRouteHook(options: EnsureHookOptions = {}): EnsureHo
       const script = ensureScript(hookDir);
       if (script === "disabled") continue; // operator opt-out — do not re-register either
       const config = ensureRegistered(spec.configPath, join(hookDir, SCRIPT_FILE));
-      results.push({ host: spec.host, script, config, scriptPath: join(hookDir, SCRIPT_FILE), configPath: spec.configPath });
+      const result: EnsureHookHostResult = { host: spec.host, script, config, scriptPath: join(hookDir, SCRIPT_FILE), configPath: spec.configPath };
+      if (spec.host === "codex") {
+        // Never report a green "registered" as if it were active: Codex
+        // SILENTLY SKIPS untrusted hooks, and "installed but inert" is the
+        // exact failure class this feature exists to end.
+        result.codexApproval = detectCodexApproval(spec.root);
+      }
+      results.push(result);
     } catch {
       // One host failing (permissions, odd config) must not block the other.
     }

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -184,7 +184,7 @@ if __name__ == "__main__":
 
 export interface EnsureHookHostResult {
   host: "claude" | "codex";
-  script: "installed" | "refreshed" | "unchanged";
+  script: "installed" | "refreshed" | "unchanged" | "disabled";
   config: "registered" | "unchanged";
   scriptPath: string;
   configPath: string;
@@ -247,12 +247,17 @@ function writeAtomically(path: string, content: string): void {
   renameSync(tmp, path);
 }
 
-function ensureScript(hookDir: string): "installed" | "refreshed" | "unchanged" {
+function ensureScript(hookDir: string): "installed" | "refreshed" | "unchanged" | "disabled" {
   const markerPath = join(hookDir, MARKER_FILE);
   const scriptPath = join(hookDir, SCRIPT_FILE);
   let existingVersion: string | undefined;
   try {
-    const marker = JSON.parse(readFileSync(markerPath, "utf8")) as { version?: string };
+    const marker = JSON.parse(readFileSync(markerPath, "utf8")) as { version?: string; disabled?: boolean };
+    // The durable off switch. Without it, an operator who deletes the entry
+    // or edits the script gets silently re-enabled by the next upgrade —
+    // self-healing becomes self-reinfecting. {"disabled": true} in the
+    // marker survives every ensure path, including version bumps.
+    if (marker.disabled === true) return "disabled";
     existingVersion = marker.version;
   } catch {
     /* no marker — install */
@@ -331,6 +336,7 @@ export function ensurePromptRouteHook(options: EnsureHookOptions = {}): EnsureHo
     try {
       const hookDir = join(spec.root, "hooks", HOOK_DIR);
       const script = ensureScript(hookDir);
+      if (script === "disabled") continue; // operator opt-out — do not re-register either
       const config = ensureRegistered(spec.configPath, join(hookDir, SCRIPT_FILE));
       results.push({ host: spec.host, script, config, scriptPath: join(hookDir, SCRIPT_FILE), configPath: spec.configPath });
     } catch {

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -216,7 +216,7 @@ export interface EnsureHookHostResult {
   /** Codex only: its trust gate silently skips unapproved hooks. We can
    *  DETECT approval only coarsely (a [hooks.state] section naming our hook);
    *  "pending-or-unknown" means the operator must run /hooks and trust it. */
-  codexApproval?: "detected" | "pending-or-unknown";
+  codexApproval?: "detected" | "pending-or-unknown" | "state-present-unverifiable";
   scriptPath: string;
   configPath: string;
 }
@@ -278,11 +278,17 @@ function hostSpecs(homeDir: string, env: NodeJS.ProcessEnv): HostSpec[] {
  * exists and mentions our hook path" (detected) or anything else
  * (pending-or-unknown). Never treat unknown as approved.
  */
-function detectCodexApproval(codexRoot: string): "detected" | "pending-or-unknown" {
+function detectCodexApproval(codexRoot: string): "detected" | "pending-or-unknown" | "state-present-unverifiable" {
   try {
     const toml = readFileSync(join(codexRoot, "config.toml"), "utf8");
-    if (/\[hooks\.state/.test(toml) && toml.includes(COMMAND_SIGNATURE)) return "detected";
-  } catch { /* unreadable = unknown */ }
+    const hasState = /\[hooks\.state/.test(toml);
+    if (hasState && toml.includes(COMMAND_SIGNATURE)) return "detected";
+    // Approvals are keyed by definition hash (algorithm not public). Once ANY
+    // trust state exists we cannot distinguish ours from here — and claiming
+    // AWAITING TRUST after the operator pressed t would be a false alarm
+    // against their own action. Distinct state, distinct wording.
+    if (hasState) return "state-present-unverifiable";
+  } catch { /* unreadable = no evidence */ }
   return "pending-or-unknown";
 }
 

--- a/src/selfUpdate.ts
+++ b/src/selfUpdate.ts
@@ -18,10 +18,13 @@
  * execution is not in that set.
  */
 import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 
 export interface SelfUpdateDeps {
   /** Currently running version (package.json). */
   currentVersion: string;
+  /** Path of the running CLI script (process.argv[1]). */
+  invokedFrom?: string;
   /** Fetch the latest published version; throws on network failure. */
   fetchLatest?: () => string;
   /** Run the global install; throws on failure. */
@@ -85,6 +88,21 @@ export function maybeSelfUpdate(deps: SelfUpdateDeps): SelfUpdateResult {
   // intent. Converging dev builds is the developer's call, not ours.
   if (deps.currentVersion.includes("-")) {
     return { action: "skipped", detail: `dev build ${deps.currentVersion} — not touching it` };
+  }
+  // A CLI running from a source checkout (repo dist, not node_modules) must
+  // never self-update: `npm i -g` would update the GLOBAL install while the
+  // re-exec re-ran THIS checkout's old code under a "updated" banner — the
+  // exact stale-code-fresh-claim confusion connect exists to end.
+  if (deps.invokedFrom) {
+    // argv[1] for a global install is the BIN SYMLINK (~/.npm-global/bin/prism),
+    // whose path contains no node_modules — judging the raw path would disable
+    // self-update for every normal install (caught empirically in review).
+    // The realpath resolves through the symlink into lib/node_modules/…
+    let resolved = deps.invokedFrom;
+    try { resolved = realpathSync(deps.invokedFrom); } catch { /* keep raw */ }
+    if (!resolved.includes("node_modules")) {
+      return { action: "skipped", detail: `running from a checkout (${resolved}) — update the checkout with git, not npm` };
+    }
   }
 
   let latest: string;

--- a/src/selfUpdate.ts
+++ b/src/selfUpdate.ts
@@ -1,0 +1,111 @@
+/**
+ * Self-update for `prism connect` — the converge command.
+ *
+ * The operator's model, which this implements: connect re-checks EVERYTHING —
+ * package version, host configs, hooks, skills — and applies what's needed.
+ * Before this, `npm i -g` and `prism connect` were two separate steps, and a
+ * machine that ran only the second stayed on old code with fresh config: the
+ * "hook exists but the CLI behind it is stale" state observed live on
+ * 2026-08-13, where a rebuilt hook called a pre-fix global CLI and quietly
+ * injected two skills instead of three.
+ *
+ * After a successful update, the caller RE-EXECS the new binary so the rest
+ * of connect runs with the code it just installed — reconciliation logic from
+ * the new version, not the old one.
+ *
+ * What this deliberately does NOT do: touch Codex hook trust. Convergence
+ * covers everything software may legitimately converge; approving our own
+ * execution is not in that set.
+ */
+import { execFileSync } from "node:child_process";
+
+export interface SelfUpdateDeps {
+  /** Currently running version (package.json). */
+  currentVersion: string;
+  /** Fetch the latest published version; throws on network failure. */
+  fetchLatest?: () => string;
+  /** Run the global install; throws on failure. */
+  install?: (version: string) => void;
+  env?: NodeJS.ProcessEnv;
+  log?: (line: string) => void;
+}
+
+export interface SelfUpdateResult {
+  action: "updated" | "current" | "skipped" | "failed";
+  detail: string;
+  latest?: string;
+}
+
+const PACKAGE = "prism-mcp-server";
+
+function defaultFetchLatest(): string {
+  return execFileSync("npm", ["view", PACKAGE, "version"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  }).trim();
+}
+
+function defaultInstall(version: string): void {
+  // Inherits the operator's npm prefix (.npmrc / NPM_CONFIG_PREFIX), so the
+  // update lands where their `prism` actually resolves from.
+  execFileSync("npm", ["install", "-g", `${PACKAGE}@${version}`], {
+    stdio: "inherit",
+    timeout: 300_000,
+  });
+}
+
+/** Plain numeric semver compare; returns true when b is newer than a. */
+export function isNewer(a: string, b: string): boolean {
+  const pa = a.split(".").map((n) => parseInt(n, 10));
+  const pb = b.split(".").map((n) => parseInt(n, 10));
+  for (let i = 0; i < 3; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (y > x) return true;
+    if (y < x) return false;
+  }
+  return false;
+}
+
+export function maybeSelfUpdate(deps: SelfUpdateDeps): SelfUpdateResult {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? (() => {});
+  const fetchLatest = deps.fetchLatest ?? defaultFetchLatest;
+  const install = deps.install ?? defaultInstall;
+
+  if (env.PRISM_NO_SELF_UPDATE === "1") {
+    return { action: "skipped", detail: "PRISM_NO_SELF_UPDATE=1" };
+  }
+  // Test runners must never reach the network or npm -g.
+  if (env.VITEST || env.NODE_ENV === "test") {
+    return { action: "skipped", detail: "test environment" };
+  }
+  // A -local.N or any prerelease build is a developer's hand-installed
+  // artifact; "updating" it to the registry release would be a DOWNGRADE of
+  // intent. Converging dev builds is the developer's call, not ours.
+  if (deps.currentVersion.includes("-")) {
+    return { action: "skipped", detail: `dev build ${deps.currentVersion} — not touching it` };
+  }
+
+  let latest: string;
+  try {
+    latest = fetchLatest();
+  } catch (error) {
+    // Offline connect must still converge configs with the code it has.
+    return { action: "failed", detail: `registry unreachable (${error instanceof Error ? error.message.split("\n")[0] : String(error)}) — continuing with ${deps.currentVersion}` };
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(latest)) {
+    return { action: "failed", detail: `registry returned unexpected version "${latest}" — continuing` };
+  }
+  if (!isNewer(deps.currentVersion, latest)) {
+    return { action: "current", detail: `${deps.currentVersion} is current`, latest };
+  }
+
+  log(`prism ${deps.currentVersion} → ${latest}: updating before configuring …`);
+  try {
+    install(latest);
+  } catch (error) {
+    return { action: "failed", detail: `npm install -g failed (${error instanceof Error ? error.message.split("\n")[0] : String(error)}) — continuing with ${deps.currentVersion}`, latest };
+  }
+  return { action: "updated", detail: `now on ${latest}`, latest };
+}

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -2044,14 +2044,22 @@ export async function seedAndRecallDemoMemory(conversationId: string): Promise<s
       limit: "1",
     })) as Array<{ summary?: string; todos?: string[] }>;
     const recalled = rows[0];
-    if (!recalled?.summary) return null;
+    if (!recalled?.summary) {
+      debugLog(`[first-run-demo] read-back returned ${Array.isArray(rows) ? rows.length : "non-array"} rows — seed row not visible`);
+      return null;
+    }
     const todo = Array.isArray(recalled.todos) && recalled.todos[0] ? `\n  - TODO it carried: ${recalled.todos[0]}` : "";
     return (
       `- 🧠 **Watch this — Prism just saved a memory and recalled it from disk:**\n` +
       `  - "${recalled.summary}"${todo}\n` +
       `  - This round-trip is what every future session gets: your decisions, TODOs, and changed files, back the moment you return. (Demo lives in the \`${DEMO_PROJECT}\` project — delete it anytime.)`
     );
-  } catch {
+  } catch (error) {
+    // Still swallow — a first run must never break on a demo — but say WHY on
+    // stderr. This block went missing intermittently on one CI leg
+    // (ubuntu/node 20) and the silent catch made every investigation start
+    // from nothing: the failure was only ever visible as an ABSENT paragraph.
+    debugLog(`[first-run-demo] seed/recall failed: ${error instanceof Error ? `${error.name}: ${error.message}` : String(error)}`);
     return null;
   }
 }

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -2186,7 +2186,15 @@ export async function collectSkillTriggersOnThisMachine(): Promise<
  */
 export async function runPromptRouteFromCache(prompt: string, loaded: string[]) {
   const { routePrompt } = await import("./promptRouteHandler.js");
-  const { resolvePromptSkillNames } = await import("./skillRouting.js");
+  const { resolvePromptSkillNames, _setStorage } = await import("./skillRouting.js");
+  // The CLI is a fresh process per prompt: without storage wiring the keyword
+  // table can neither be read from disk (offline = dead routing) nor
+  // persisted after a fetch (every prompt = a network GET). The server paths
+  // wire this at bootstrap; the CLI must do it itself.
+  _setStorage(
+    async (key, value) => { await setSetting(key, value); },
+    async (key) => getSetting(key, ""),
+  );
   return routePrompt(prompt, loaded, {
     resolvePromptSkillNames,
     collectTriggers: collectSkillTriggersOnThisMachine,

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -2045,7 +2045,7 @@ export async function seedAndRecallDemoMemory(conversationId: string): Promise<s
     })) as Array<{ summary?: string; todos?: string[] }>;
     const recalled = rows[0];
     if (!recalled?.summary) {
-      debugLog(`[first-run-demo] read-back returned ${Array.isArray(rows) ? rows.length : "non-array"} rows — seed row not visible`);
+      console.error(`[first-run-demo] read-back returned ${Array.isArray(rows) ? rows.length : "non-array"} rows — seed row not visible`);
       return null;
     }
     const todo = Array.isArray(recalled.todos) && recalled.todos[0] ? `\n  - TODO it carried: ${recalled.todos[0]}` : "";
@@ -2059,7 +2059,7 @@ export async function seedAndRecallDemoMemory(conversationId: string): Promise<s
     // stderr. This block went missing intermittently on one CI leg
     // (ubuntu/node 20) and the silent catch made every investigation start
     // from nothing: the failure was only ever visible as an ABSENT paragraph.
-    debugLog(`[first-run-demo] seed/recall failed: ${error instanceof Error ? `${error.name}: ${error.message}` : String(error)}`);
+    console.error(`[first-run-demo] seed/recall failed: ${error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : String(error)}`);
     return null;
   }
 }

--- a/src/tools/promptRouteHandler.ts
+++ b/src/tools/promptRouteHandler.ts
@@ -29,8 +29,14 @@ import { debugLog } from "../utils/logger.js";
 
 /** Never return more than this many bodies in one call. */
 export const MAX_ROUTED_SKILLS = 3;
-/** Hard ceiling on returned characters, so one call cannot flood the window. */
-export const MAX_ROUTED_CHARS = 24_000;
+/** Hard ceiling on returned characters, so one call cannot flood the window.
+ *  Sized from measurement, not taste: the UI-review bundle
+ *  (visual-screenshot-verification + playwright-screenshot-discipline +
+ *  verified-shipping) is ~24.5k, and at 24k the third — the EVIDENCE-CLAIM
+ *  rules, arguably the one that matters most at the merge moment — was
+ *  reported "matched, not injected" on the first UI turn of a live session.
+ *  A cap that trims the bundle it was built for is mis-sized. */
+export const MAX_ROUTED_CHARS = 30_000;
 
 export interface PromptRouteDeps {
   /** On-device matcher — same one session_bootstrap uses. */

--- a/src/tools/promptRouteHandler.ts
+++ b/src/tools/promptRouteHandler.ts
@@ -213,39 +213,62 @@ export function reshapeForInlineBudget(
     offloadPath = undefined;
   }
 
-  const pieces: string[] = [result.header];
+  // POINTER FIRST. Recoverability outranks prose order: skill names are
+  // unbounded (portal manifest, unvalidated), so any text placed before the
+  // pointer can push it past the ~2KB preview a host shows for offloaded
+  // context — or under the final clamp, slice it off entirely. Round-2 review
+  // measured both: 200-char names put the pointer at offset ~2,374 with the
+  // clamp never firing. With the pointer leading, its path sits within the
+  // first ~120 chars no matter what the header does.
+  const pieces: string[] = [];
   if (offloadPath) {
     pieces.push(
       `**Host hook context is size-capped — the full text of all ${result.names.length} skill(s) is saved at: ${offloadPath}**\n` +
         `**Read that file now and follow those skills before proceeding. If the host shows "Full output saved to" with another path above, Read that file instead.**`,
     );
   }
+  pieces.push(result.header);
 
-  // Reserve room for the loud-failure footer when there is no offload file to
-  // point at — a silently dropped skill is the defect this feature exists for.
-  // COMPUTED from the worst-case footer (every delivered name skipped), not a
-  // guessed constant: a fixed 300 was measured overrunning the budget by 99
-  // chars with two long-named skills.
+  // Loud-failure footer when there is no offload file to point at — a
+  // silently dropped skill is the defect this feature exists for. The reserve
+  // is an EXACT FIXPOINT over the skipped set, not a bound: reserving for all
+  // delivered names was measured skipping a body that previously fit (188
+  // wasted chars), and a guessed constant was measured overrunning by 99.
+  // The skipped set only grows as the reserve grows, so this converges in at
+  // most blocks+1 rounds.
   const footerFor = (names: string[]) =>
     `\n\n**Not inlined (host size cap, offload unavailable): ${names.join(", ")} — fetch each with knowledge_search and follow it before proceeding.**`;
-  const reserve = offloadPath ? 0 : footerFor(result.names).length;
-  let inline = pieces.join("\n\n");
-  const skipped: string[] = [];
-  for (let i = 0; i < result.blocks.length; i++) {
-    const candidate = `${inline}\n\n${result.blocks[i]}`;
-    if (candidate.length <= budgetChars - reserve) {
-      inline = candidate;
-    } else {
-      skipped.push(result.names[i] ?? `skill ${i + 1}`);
+  const base = pieces.join("\n\n");
+  const blocks = result.blocks; // narrowed once — the closure below defeats TS narrowing on result
+  const fill = (reserve: number) => {
+    let filled = base;
+    const skipped: string[] = [];
+    for (let i = 0; i < blocks.length; i++) {
+      const candidate = `${filled}\n\n${blocks[i]}`;
+      if (candidate.length <= budgetChars - reserve) {
+        filled = candidate;
+      } else {
+        skipped.push(result.names[i] ?? `skill ${i + 1}`);
+      }
+    }
+    return { filled, skipped };
+  };
+  let attempt = fill(0);
+  if (!offloadPath) {
+    for (let round = 0; round <= blocks.length && attempt.skipped.length > 0; round++) {
+      const next = fill(footerFor(attempt.skipped).length);
+      const converged = next.skipped.length === attempt.skipped.length;
+      attempt = next;
+      if (converged) break;
     }
   }
-  if (!offloadPath && skipped.length > 0) {
-    inline += footerFor(skipped);
+  let inline = attempt.filled;
+  if (!offloadPath && attempt.skipped.length > 0) {
+    inline += footerFor(attempt.skipped);
   }
   // Belt over the construction: the budget is a HOST hard cap, and "the data
-  // stayed small" is not an invariant. If a pathological header ever pushes
-  // the base past it, keep the first budgetChars — the names line and pointer
-  // sit at the front by construction, so what survives is the recoverable part.
+  // stayed small" is not an invariant. The pointer leads, so a slice keeps
+  // the recoverable part.
   if (inline.length > budgetChars) {
     inline = inline.slice(0, budgetChars);
   }

--- a/src/tools/promptRouteHandler.ts
+++ b/src/tools/promptRouteHandler.ts
@@ -156,10 +156,21 @@ export async function routePrompt(
 
   // Imperative, not a label. A bare list is decorative; nothing else in this
   // path tells the agent these rules bind the work it is about to do.
+  //
+  // The overflow list is CAPPED: the header feeds reshapeForInlineBudget's
+  // base text, whose budget guarantee (and the pointer's first-2KB placement)
+  // holds only if the header is bounded. An unbounded list of matched names
+  // was measured at 12,950 chars for a 400-skill match — over the host cap
+  // before a single body was added.
+  const overflowShown = overflow.slice(0, 8);
+  const overflowNote =
+    overflow.length > 0
+      ? `\n\nAlso matched, not injected: ${overflowShown.join(", ")}${overflow.length > overflowShown.length ? ` (+${overflow.length - overflowShown.length} more)` : ""}.`
+      : "";
   const header =
     `**Skills now active for this task:** ${delivered.join(", ")}\n\n` +
     `These apply to the work you are about to do. Read and follow them before proceeding.` +
-    (overflow.length > 0 ? `\n\nAlso matched, not injected: ${overflow.join(", ")}.` : "");
+    overflowNote;
 
   return { names: delivered, alreadyLoaded, overflow, header, blocks, text: `${header}\n\n${blocks.join("\n\n")}` };
 }
@@ -212,7 +223,12 @@ export function reshapeForInlineBudget(
 
   // Reserve room for the loud-failure footer when there is no offload file to
   // point at — a silently dropped skill is the defect this feature exists for.
-  const reserve = offloadPath ? 0 : 300;
+  // COMPUTED from the worst-case footer (every delivered name skipped), not a
+  // guessed constant: a fixed 300 was measured overrunning the budget by 99
+  // chars with two long-named skills.
+  const footerFor = (names: string[]) =>
+    `\n\n**Not inlined (host size cap, offload unavailable): ${names.join(", ")} — fetch each with knowledge_search and follow it before proceeding.**`;
+  const reserve = offloadPath ? 0 : footerFor(result.names).length;
   let inline = pieces.join("\n\n");
   const skipped: string[] = [];
   for (let i = 0; i < result.blocks.length; i++) {
@@ -224,7 +240,14 @@ export function reshapeForInlineBudget(
     }
   }
   if (!offloadPath && skipped.length > 0) {
-    inline += `\n\n**Not inlined (host size cap, offload unavailable): ${skipped.join(", ")} — fetch each with knowledge_search and follow it before proceeding.**`;
+    inline += footerFor(skipped);
+  }
+  // Belt over the construction: the budget is a HOST hard cap, and "the data
+  // stayed small" is not an invariant. If a pathological header ever pushes
+  // the base past it, keep the first budgetChars — the names line and pointer
+  // sit at the front by construction, so what survives is the recoverable part.
+  if (inline.length > budgetChars) {
+    inline = inline.slice(0, budgetChars);
   }
   return { text: inline, offloaded: true, offloadPath };
 }

--- a/src/tools/promptRouteHandler.ts
+++ b/src/tools/promptRouteHandler.ts
@@ -37,6 +37,14 @@ export const MAX_ROUTED_SKILLS = 3;
  *  reported "matched, not injected" on the first UI turn of a live session.
  *  A cap that trims the bundle it was built for is mis-sized. */
 export const MAX_ROUTED_CHARS = 30_000;
+/** What a HOST will actually hand the model inline from a hook. Claude Code
+ *  hard-caps hook additionalContext at 10,000 chars — over that, the full text
+ *  goes to a file and the model gets a 2KB preview (three live instances
+ *  observed 2026-08-13: 13.2/18/18.9KB injections, all offloaded). Codex
+ *  truncates at ~2,500 tokens by default. MAX_ROUTED_CHARS bounds the PAYLOAD;
+ *  this bounds what may ride INLINE through a hook — anything larger must be
+ *  our own offload file with an imperative pointer, not the host's silent one. */
+export const HOOK_INLINE_SAFE_CHARS = 9_800;
 
 export interface PromptRouteDeps {
   /** On-device matcher — same one session_bootstrap uses. */
@@ -66,6 +74,10 @@ export interface PromptRouteResult {
   alreadyLoaded: string[];
   /** Matched but dropped by the per-call cap. */
   overflow: string[];
+  /** Imperative header, kept separate so hook callers can re-budget inline text. */
+  header?: string;
+  /** One `### name\nbody` block per delivered skill, in priority order. */
+  blocks?: string[];
 }
 
 /**
@@ -149,5 +161,70 @@ export async function routePrompt(
     `These apply to the work you are about to do. Read and follow them before proceeding.` +
     (overflow.length > 0 ? `\n\nAlso matched, not injected: ${overflow.join(", ")}.` : "");
 
-  return { names: delivered, alreadyLoaded, overflow, text: `${header}\n\n${blocks.join("\n\n")}` };
+  return { names: delivered, alreadyLoaded, overflow, header, blocks, text: `${header}\n\n${blocks.join("\n\n")}` };
+}
+
+export interface InlineShaped {
+  /** What the hook should emit as additionalContext. */
+  text: string;
+  /** True when the full payload did not fit inline. */
+  offloaded: boolean;
+  /** Where the full payload was written, when the writer succeeded. */
+  offloadPath?: string;
+}
+
+/**
+ * Fit a routed payload under a host's inline hook cap.
+ *
+ * The host's own overflow handling is the failure mode, not the fallback:
+ * Claude Code silently swaps anything over 10k chars for a 2KB preview, and
+ * nothing tells the model to go read the rest. So when the payload is over
+ * budget WE offload it — to a file we name, behind an imperative that sits in
+ * the first 2KB where every host preview window can still deliver it — and
+ * inline as many whole priority bodies as fit.
+ *
+ * Pure over its writer so tests exercise the real budgeting.
+ */
+export function reshapeForInlineBudget(
+  result: PromptRouteResult,
+  budgetChars: number,
+  writeOffload: (fullText: string) => string | undefined,
+): InlineShaped {
+  const full = result.text;
+  if (full.length <= budgetChars || !result.header || !result.blocks || result.blocks.length === 0) {
+    return { text: full, offloaded: false };
+  }
+
+  let offloadPath: string | undefined;
+  try {
+    offloadPath = writeOffload(full);
+  } catch {
+    offloadPath = undefined;
+  }
+
+  const pieces: string[] = [result.header];
+  if (offloadPath) {
+    pieces.push(
+      `**Host hook context is size-capped — the full text of all ${result.names.length} skill(s) is saved at: ${offloadPath}**\n` +
+        `**Read that file now and follow those skills before proceeding. If the host shows "Full output saved to" with another path above, Read that file instead.**`,
+    );
+  }
+
+  // Reserve room for the loud-failure footer when there is no offload file to
+  // point at — a silently dropped skill is the defect this feature exists for.
+  const reserve = offloadPath ? 0 : 300;
+  let inline = pieces.join("\n\n");
+  const skipped: string[] = [];
+  for (let i = 0; i < result.blocks.length; i++) {
+    const candidate = `${inline}\n\n${result.blocks[i]}`;
+    if (candidate.length <= budgetChars - reserve) {
+      inline = candidate;
+    } else {
+      skipped.push(result.names[i] ?? `skill ${i + 1}`);
+    }
+  }
+  if (!offloadPath && skipped.length > 0) {
+    inline += `\n\n**Not inlined (host size cap, offload unavailable): ${skipped.join(", ")} — fetch each with knowledge_search and follow it before proceeding.**`;
+  }
+  return { text: inline, offloaded: true, offloadPath };
 }

--- a/src/tools/skillRouting.ts
+++ b/src/tools/skillRouting.ts
@@ -260,6 +260,23 @@ async function fetchKeywordTable(expectVersion?: number): Promise<KeywordTable |
     kwCache = null;
   }
   if (kwCache && Date.now() - kwCache.at < TABLE_TTL) return kwCache.table;
+  // Persisted-first when the version is KNOWN-GOOD. The in-memory cache is
+  // per-process, and the route-prompt CLI is a fresh process on EVERY user
+  // prompt — without this, each prompt made a network GET (measured: a
+  // captive-portal network stalled every prompt 5.5s, and offline routed
+  // nothing because a fresh process had no fallback wired). A persisted
+  // table whose version equals what the manifest sync last reported is
+  // exactly as fresh as a re-download; version bumps still refetch below.
+  if (expectVersion !== undefined && readFn) {
+    try {
+      const stored = await readFn(TABLE_STORAGE_KEY);
+      const parsed: unknown = stored ? JSON.parse(stored) : null;
+      if (isKeywordTable(parsed) && parsed.version === expectVersion) {
+        kwCache = { table: parsed, at: Date.now() };
+        return parsed;
+      }
+    } catch { /* fall through to network */ }
+  }
   if (!kwInflight) {
     kwInflight = (async (): Promise<KeywordTable | null> => {
       try {

--- a/tests/prompt-route-host-hook.test.ts
+++ b/tests/prompt-route-host-hook.test.ts
@@ -225,6 +225,16 @@ if [ "$3" = "" ]; then echo '{"names":["visual-screenshot-verification"],"text":
     expect(out).toEqual({ continue: true, suppressOutput: true });
   });
 
+  it("survives stdout pollution from node wrappers (dotenv banners etc.)", () => {
+    writeFileSync(stub, `#!/bin/bash
+echo "[dotenv] injected env (10) from .env"
+echo '{"names":["visual-screenshot-verification"],"text":"BODY"}'
+`);
+    chmodSync(stub, 0o755);
+    const out = run({ prompt: "the totals are not sticky", session_id: "s9" });
+    expect(out.hookSpecificOutput?.additionalContext).toBe("BODY");
+  });
+
   it("passes through on garbage stdin", () => {
     const out = JSON.parse(
       execFileSync("python3", [script], {

--- a/tests/prompt-route-host-hook.test.ts
+++ b/tests/prompt-route-host-hook.test.ts
@@ -100,6 +100,27 @@ describe("install", () => {
   });
 });
 
+describe("opt-out — disabled marker survives upgrades", () => {
+  it("a marker with disabled:true blocks reinstall AND re-registration on every path", () => {
+    ensurePromptRouteHook({ homeDir: home, env: {} });
+    const hookDir = join(home, ".claude", "hooks", "prism-route");
+    // Operator turns it off: marks disabled, removes the registration.
+    writeFileSync(join(hookDir, ".prism-managed.json"), JSON.stringify({ managedBy: "prism", disabled: true }));
+    const cfg = JSON.parse(readFileSync(join(home, ".claude", "settings.json"), "utf8"));
+    cfg.hooks.UserPromptSubmit = [];
+    writeFileSync(join(home, ".claude", "settings.json"), JSON.stringify(cfg, null, 2));
+
+    // Upgrade paths must NOT resurrect it — self-healing must not be
+    // self-reinfecting.
+    for (const mode of ["explicit", "auto"] as const) {
+      const results = ensurePromptRouteHook({ homeDir: home, env: {}, mode });
+      expect(results.find((r) => r.host === "claude")).toBeUndefined();
+    }
+    const after = JSON.parse(readFileSync(join(home, ".claude", "settings.json"), "utf8"));
+    expect(after.hooks.UserPromptSubmit).toEqual([]);
+  });
+});
+
 describe("consent — auto paths must not touch a stranger's machine", () => {
   // prism-mcp-server is PUBLIC npm. postinstall and server-start run on every
   // machine that installs it, including people who never ran `prism connect`.

--- a/tests/prompt-route-host-hook.test.ts
+++ b/tests/prompt-route-host-hook.test.ts
@@ -38,7 +38,10 @@ describe("install", () => {
     for (const cfg of [claudeConfig(), codexConfig()]) {
       // JSON.stringify doubles backslashes on Windows; normalize before matching.
       const cmds = JSON.stringify(cfg.hooks.UserPromptSubmit).replace(/\\+/g, "/");
-      expect(cmds).toContain("prism-route/on_prompt.py");
+      // The version rides in the CONFIGURED COMMAND: Codex's trust hash covers
+      // the definition, not the script file, so a version-refreshed script
+      // behind a stable command would silently change trusted content.
+      expect(cmds).toContain(`prism-route/on_prompt.py --v${PROMPT_ROUTE_HOOK_VERSION}`);
     }
     expect(existsSync(join(home, ".claude", "hooks", "prism-route", "on_prompt.py"))).toBe(true);
     expect(existsSync(join(home, ".codex", "hooks", "prism-route", "state"))).toBe(true);
@@ -71,6 +74,32 @@ describe("install", () => {
     expect(cfg.hooks.PreToolUse).toHaveLength(1);
     expect(cfg.hooks.UserPromptSubmit).toHaveLength(2);
     expect(JSON.stringify(cfg.hooks.UserPromptSubmit[0])).toContain("screenshot-first");
+  });
+
+  it("a version bump UPDATES the registered command in place — no duplicate, new trust hash", () => {
+    ensurePromptRouteHook({ homeDir: home, env: {} });
+    // Simulate a previous release: old marker AND an old-style command.
+    const cfgPath = join(home, ".codex", "hooks.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    const hook = cfg.hooks.UserPromptSubmit[0].hooks[0];
+    hook.command = hook.command.replace(/ --v\d+$/, " --v0");
+    writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+    writeFileSync(join(home, ".codex", "hooks", "prism-route", ".prism-managed.json"),
+      JSON.stringify({ managedBy: "prism", version: "0" }));
+
+    const results = ensurePromptRouteHook({ homeDir: home, env: {} });
+    const codex = results.find((r) => r.host === "codex");
+    expect(codex?.config).toBe("updated");
+    const after = JSON.parse(readFileSync(cfgPath, "utf8"));
+    const cmds = after.hooks.UserPromptSubmit.flatMap((e: { hooks: Array<{ command: string }> }) => e.hooks.map((h) => h.command));
+    expect(cmds.filter((c: string) => c.includes("prism-route"))).toHaveLength(1); // replaced, not appended
+    expect(cmds[0]).toContain(`--v${PROMPT_ROUTE_HOOK_VERSION}`);
+  });
+
+  it("codex results carry the approval hint — registered is NOT active", () => {
+    const results = ensurePromptRouteHook({ homeDir: home, env: {} });
+    expect(results.find((r) => r.host === "codex")?.codexApproval).toBe("pending-or-unknown");
+    expect(results.find((r) => r.host === "claude")?.codexApproval).toBeUndefined();
   });
 
   it("refreshes the script when the version marker is older", () => {

--- a/tests/prompt-route-host-hook.test.ts
+++ b/tests/prompt-route-host-hook.test.ts
@@ -96,6 +96,35 @@ describe("install", () => {
     expect(cmds[0]).toContain(`--v${PROMPT_ROUTE_HOOK_VERSION}`);
   });
 
+  it("codex registration carries additionalContextLimit: 0 — the default (~2,500 tokens) truncates our payload to a preview", () => {
+    ensurePromptRouteHook({ homeDir: home, env: {} });
+    const entry = codexConfig().hooks.UserPromptSubmit.find((e: unknown) => JSON.stringify(e).includes("prism-route"));
+    expect(entry.hooks[0].additionalContextLimit).toBe(0);
+  });
+
+  it("claude registration does NOT carry the codex-only field — no unknown keys in settings.json", () => {
+    ensurePromptRouteHook({ homeDir: home, env: {} });
+    const entry = claudeConfig().hooks.UserPromptSubmit.find((e: unknown) => JSON.stringify(e).includes("prism-route"));
+    expect("additionalContextLimit" in entry.hooks[0]).toBe(false);
+  });
+
+  it("a codex entry missing the field is CONVERGED in place — no duplicate entry", () => {
+    // The state every machine registered before this fix is in right now.
+    ensurePromptRouteHook({ homeDir: home, env: {} });
+    const cfgPath = join(home, ".codex", "hooks.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf8"));
+    delete cfg.hooks.UserPromptSubmit[0].hooks[0].additionalContextLimit;
+    writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+
+    const results = ensurePromptRouteHook({ homeDir: home, env: {} });
+    expect(results.find((r) => r.host === "codex")?.config).toBe("updated");
+    const after = JSON.parse(readFileSync(cfgPath, "utf8"));
+    const ours = after.hooks.UserPromptSubmit.flatMap((e: { hooks: Array<{ command: string }> }) => e.hooks)
+      .filter((h: { command: string }) => h.command.includes("prism-route"));
+    expect(ours).toHaveLength(1); // converged, not appended
+    expect((ours[0] as { additionalContextLimit?: number }).additionalContextLimit).toBe(0);
+  });
+
   it("codex results carry the approval hint — registered is NOT active", () => {
     const results = ensurePromptRouteHook({ homeDir: home, env: {} });
     expect(results.find((r) => r.host === "codex")?.codexApproval).toBe("pending-or-unknown");

--- a/tests/self-update.test.ts
+++ b/tests/self-update.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Self-update inside `prism connect` — the converge command.
+ *
+ * The dangerous cases are the SKIPS and FAILURES, because each one is a
+ * machine that keeps working with the code it has: a converge command that
+ * bricks a machine on a network error, or "upgrades" a developer's
+ * hand-installed build to an older registry release, teaches people to stop
+ * running it.
+ */
+import { describe, it, expect } from "vitest";
+import { maybeSelfUpdate, isNewer } from "../src/selfUpdate.js";
+
+const noEnv = {}; // deliberately NOT process.env — vitest sets VITEST there
+
+describe("version comparison", () => {
+  it.each([
+    ["20.10.0", "20.11.0", true],
+    ["20.10.0", "21.0.0", true],
+    ["20.10.0", "20.10.1", true],
+    ["20.10.0", "20.10.0", false],
+    ["20.11.0", "20.10.9", false],
+    ["20.10.0", "3.9.9", false],
+  ])("%s -> %s newer=%s", (a, b, want) => {
+    expect(isNewer(a, b)).toBe(want);
+  });
+});
+
+describe("maybeSelfUpdate", () => {
+  it("updates and reports when the registry is ahead", () => {
+    const installed: string[] = [];
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.0",
+      env: noEnv,
+      fetchLatest: () => "20.11.0",
+      install: (v) => installed.push(v),
+    });
+    expect(r.action).toBe("updated");
+    expect(installed).toEqual(["20.11.0"]);
+  });
+
+  it("does nothing when current", () => {
+    const r = maybeSelfUpdate({
+      currentVersion: "20.11.0", env: noEnv,
+      fetchLatest: () => "20.11.0",
+      install: () => { throw new Error("must not install"); },
+    });
+    expect(r.action).toBe("current");
+  });
+
+  it("NEVER touches a dev build — registry 'latest' would be a downgrade of intent", () => {
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.1-local.6", env: noEnv,
+      fetchLatest: () => { throw new Error("must not even fetch"); },
+      install: () => { throw new Error("must not install"); },
+    });
+    expect(r.action).toBe("skipped");
+    expect(r.detail).toContain("dev build");
+  });
+
+  it("offline: reports and continues — a converge command must not brick on network", () => {
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.0", env: noEnv,
+      fetchLatest: () => { throw new Error("ENOTFOUND registry.npmjs.org"); },
+      install: () => { throw new Error("must not install"); },
+    });
+    expect(r.action).toBe("failed");
+    expect(r.detail).toContain("continuing with 20.10.0");
+  });
+
+  it("a failed install continues with the current version rather than aborting connect", () => {
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.0", env: noEnv,
+      fetchLatest: () => "20.11.0",
+      install: () => { throw new Error("EACCES"); },
+    });
+    expect(r.action).toBe("failed");
+    expect(r.detail).toContain("npm install -g failed");
+  });
+
+  it("garbage from the registry is refused, not installed", () => {
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.0", env: noEnv,
+      fetchLatest: () => "banana; rm -rf /",
+      install: () => { throw new Error("must not install"); },
+    });
+    expect(r.action).toBe("failed");
+    expect(r.detail).toContain("unexpected version");
+  });
+
+  it("PRISM_NO_SELF_UPDATE=1 and test environments skip without network", () => {
+    for (const env of [{ PRISM_NO_SELF_UPDATE: "1" }, { VITEST: "true" }, { NODE_ENV: "test" }]) {
+      const r = maybeSelfUpdate({
+        currentVersion: "20.10.0", env,
+        fetchLatest: () => { throw new Error("must not fetch"); },
+        install: () => { throw new Error("must not install"); },
+      });
+      expect(r.action).toBe("skipped");
+    }
+  });
+});

--- a/tests/self-update.test.ts
+++ b/tests/self-update.test.ts
@@ -7,7 +7,14 @@
  * hand-installed build to an older registry release, teaches people to stop
  * running it.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, symlinkSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmp: string;
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "selfupd-")); });
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
 import { maybeSelfUpdate, isNewer } from "../src/selfUpdate.js";
 
 const noEnv = {}; // deliberately NOT process.env — vitest sets VITEST there
@@ -22,6 +29,32 @@ describe("version comparison", () => {
     ["20.10.0", "3.9.9", false],
   ])("%s -> %s newer=%s", (a, b, want) => {
     expect(isNewer(a, b)).toBe(want);
+  });
+});
+
+describe("invocation-path guard", () => {
+  it("a checkout path skips — npm would update the global while re-exec ran old code", () => {
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.0", env: noEnv, invokedFrom: "/Users/dev/prism/dist/cli.js",
+      fetchLatest: () => { throw new Error("must not fetch"); },
+      install: () => { throw new Error("must not install"); },
+    });
+    expect(r.action).toBe("skipped");
+    expect(r.detail).toContain("checkout");
+  });
+
+  it("a global BIN SYMLINK does NOT skip — argv[1] has no node_modules but its realpath does", () => {
+    // The empirical case that broke the first version of this guard.
+    const bin = join(tmp, "bin"); const lib = join(tmp, "lib", "node_modules", "pkg", "dist");
+    mkdirSync(bin, { recursive: true }); mkdirSync(lib, { recursive: true });
+    writeFileSync(join(lib, "cli.js"), "");
+    symlinkSync(join("..", "lib", "node_modules", "pkg", "dist", "cli.js"), join(bin, "prism"));
+    const r = maybeSelfUpdate({
+      currentVersion: "20.10.0", env: noEnv, invokedFrom: join(bin, "prism"),
+      fetchLatest: () => "20.10.0", // current → clean stop after passing the guard
+      install: () => { throw new Error("must not install"); },
+    });
+    expect(r.action).toBe("current");
   });
 });
 

--- a/tests/skill-routing.test.ts
+++ b/tests/skill-routing.test.ts
@@ -741,3 +741,26 @@ describe('emitted startup text carries no strippable placeholders', () => {
     // (retrieval-call assertion removed: the body is inlined, not fetched)
   });
 });
+
+describe("keyword table — persisted-first (the route-prompt CLI is a fresh process per prompt)", () => {
+  // Found in review round 4: the in-memory table cache is per-process, so the
+  // hook CLI fetched the PUBLIC routing table over the network on EVERY user
+  // prompt — measured 5.5s per prompt on a black-holed network, and zero
+  // routing offline because no storage was wired. A persisted table whose
+  // version equals the manifest-synced expectation must satisfy the resolver
+  // with no network at all.
+  it("routes offline from the persisted table when versions match", async () => {
+    const { _setStorage, resolvePromptSkillNames } = await import("../src/tools/skillRouting.js");
+    const table = JSON.stringify({ version: 99, prompt_keywords: { "\\bnot sticky\\b": ["visual-screenshot-verification"] } });
+    _setStorage(async () => {}, async (key) => (key === "routing_keywords" ? table : ""));
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() => { throw new Error("network must not be touched"); }) as never;
+    try {
+      const names = await resolvePromptSkillNames("the totals are not sticky", 99);
+      expect(names).toContain("visual-screenshot-verification");
+    } finally {
+      globalThis.fetch = realFetch;
+      _setStorage(null as never, null as never);
+    }
+  });
+});

--- a/tests/tools/cli-connect.test.ts
+++ b/tests/tools/cli-connect.test.ts
@@ -50,6 +50,7 @@ import {
   computeSkillManifestGeneration,
   type SkillManifest,
 } from "../../src/skillManifestSync.js";
+import { PROMPT_ROUTE_HOOK_VERSION } from "../../src/promptRouteHostHook.js";
 import { FREE_NATIVE_SKILL_NAMES } from "../../src/tools/skillRouting.js";
 
 const tempHomes: string[] = [];
@@ -1940,7 +1941,7 @@ it("reports the Claude project migration on default and refresh dry runs only af
           matcher: "*",
           hooks: [{
             type: "command",
-            command: `python3 ${join(homeDir, ".claude", "hooks", "prism-route", "on_prompt.py")}`,
+            command: `python3 ${join(homeDir, ".claude", "hooks", "prism-route", "on_prompt.py")} --v${PROMPT_ROUTE_HOOK_VERSION}`,
             timeout: 15,
           }],
         }],

--- a/tests/tools/prompt-route.test.ts
+++ b/tests/tools/prompt-route.test.ts
@@ -172,6 +172,39 @@ describe("host inline budget — hosts hard-cap hook context (Claude Code 10k ch
     expect(shaped.text).toMatch(/knowledge_search/);
     expect(shaped.text).toContain("gamma"); // the dropped skill is named, not silently gone
   });
+
+  it("a 400-skill match cannot blow the budget through the overflow header, and the pointer stays in the first 2KB", async () => {
+    // Adversarial review measured the unbounded overflow list at 12,950 header
+    // chars for 400 matched skills — over the host cap before any body, with
+    // the pointer pushed past every preview window. The cap must hold by
+    // construction, not because the catalog happens to be small.
+    const many = Array.from({ length: 400 }, (_, i) => `team-scoped-skill-with-a-long-name-${String(i).padStart(3, "0")}`);
+    const r = await routePrompt("ui/ux", [], deps({
+      resolvePromptSkillNames: async () => many,
+      entitledNames: async () => new Set(many),
+      getBody: async () => `# body\n${"x".repeat(6_000)}`,
+    }));
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => "/tmp/prism-test/route-400.md");
+    expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS);
+    expect(shaped.text.slice(0, 2_048)).toContain("/tmp/prism-test/route-400.md");
+    expect(shaped.text).toContain("+"); // capped overflow list says "+N more" instead of listing 397 names
+  });
+
+  it("writer failure with long skill names cannot overrun the budget — the footer reserve is computed, not guessed", async () => {
+    // Measured pre-fix: fixed reserve of 300 emitted 9,899 > 9,800 with two
+    // ~148-char skipped names.
+    const longNames = ["a".repeat(148), "b".repeat(148), "c".repeat(148)];
+    const r = await routePrompt("ui/ux", [], deps({
+      resolvePromptSkillNames: async () => longNames,
+      entitledNames: async () => new Set(longNames),
+      // Sized so the first body lands just under the old fixed reserve's fill
+      // line (budget−300) while the real footer for the two skipped 148-char
+      // names is ~417 chars — the geometry the review measured overrunning.
+      getBody: async () => `# body\n${"x".repeat(8_700)}`,
+    }));
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => undefined);
+    expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS);
+  });
 });
 
 describe("entitlement and privacy", () => {

--- a/tests/tools/prompt-route.test.ts
+++ b/tests/tools/prompt-route.test.ts
@@ -7,7 +7,13 @@
  * as the injection path itself.
  */
 import { describe, it, expect } from "vitest";
-import { routePrompt, MAX_ROUTED_SKILLS, MAX_ROUTED_CHARS } from "../../src/tools/promptRouteHandler.js";
+import {
+  routePrompt,
+  reshapeForInlineBudget,
+  MAX_ROUTED_SKILLS,
+  MAX_ROUTED_CHARS,
+  HOOK_INLINE_SAFE_CHARS,
+} from "../../src/tools/promptRouteHandler.js";
 
 const BODIES: Record<string, string> = {
   "visual-screenshot-verification": "# visual\nRender it and look at it.",
@@ -102,6 +108,69 @@ describe("injection", () => {
     }));
     expect(r.names).toEqual(["ghost"]);
     expect(r.text).toMatch(/no content on this machine/i);
+  });
+});
+
+describe("host inline budget — hosts hard-cap hook context (Claude Code 10k chars, Codex ~2.5k tokens)", () => {
+  // Three live instances on 2026-08-13: 13.2KB/18KB/18.9KB injections were
+  // offloaded by Claude Code to a file the model never read past a 2KB
+  // preview. The full payload must therefore be OUR offload, with an
+  // imperative pointer that survives any preview window.
+  const SIX_K = "R".repeat(6_000);
+  const threeBigSkills = () => deps({
+    resolvePromptSkillNames: async () => ["alpha", "beta", "gamma"],
+    entitledNames: async () => new Set(["alpha", "beta", "gamma"]),
+    getBody: async (n: string) => `# ${n}\n${SIX_K}`,
+  });
+
+  it("pins the budget under Claude Code's documented 10,000-char hook cap", () => {
+    expect(HOOK_INLINE_SAFE_CHARS).toBeLessThan(10_000);
+    expect(HOOK_INLINE_SAFE_CHARS).toBeGreaterThan(8_000);
+  });
+
+  it("over budget: inline fits the cap, the file gets the FULL text, and the Read pointer sits in the first 2KB", async () => {
+    const r = await routePrompt("ui/ux", [], threeBigSkills());
+    expect(r.text.length).toBeGreaterThan(HOOK_INLINE_SAFE_CHARS); // precondition: this IS the failing payload
+    let written: string | undefined;
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, (full) => {
+      written = full;
+      return "/tmp/prism-test/route-1.md";
+    });
+    expect(shaped.offloaded).toBe(true);
+    expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS);
+    expect(written).toBe(r.text); // byte-complete: the file is the payload, not a summary
+    const preview = shaped.text.slice(0, 2_048); // what Claude Code's preview would show
+    expect(preview).toContain("/tmp/prism-test/route-1.md");
+    expect(preview).toMatch(/Read that file now/i);
+    expect(preview).toContain("**Skills now active for this task:** alpha, beta, gamma");
+  });
+
+  it("inlines whole priority bodies that still fit under the budget", async () => {
+    const r = await routePrompt("ui/ux", [], threeBigSkills());
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => "/tmp/p.md");
+    // 6k bodies: the first fits under 9.8k alongside header+pointer, the rest must not.
+    expect(shaped.text).toContain("### alpha");
+    expect(shaped.text).not.toContain("### gamma");
+  });
+
+  it("under budget: text passes through untouched and nothing is written", async () => {
+    const r = await routePrompt("make a UI/UX review", [], deps());
+    let calls = 0;
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => {
+      calls += 1;
+      return "/tmp/never.md";
+    });
+    expect(shaped.offloaded).toBe(false);
+    expect(shaped.text).toBe(r.text);
+    expect(calls).toBe(0);
+  });
+
+  it("offload write failure degrades LOUDLY: skipped skills are named with a fetch instruction", async () => {
+    const r = await routePrompt("ui/ux", [], threeBigSkills());
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => undefined);
+    expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS);
+    expect(shaped.text).toMatch(/knowledge_search/);
+    expect(shaped.text).toContain("gamma"); // the dropped skill is named, not silently gone
   });
 });
 

--- a/tests/tools/prompt-route.test.ts
+++ b/tests/tools/prompt-route.test.ts
@@ -204,6 +204,66 @@ describe("host inline budget — hosts hard-cap hook context (Claude Code 10k ch
     }));
     const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => undefined);
     expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS);
+    // The footer must arrive INTACT — a guessed reserve plus the final clamp
+    // would slice its tail off, which the length assertion alone cannot see.
+    // (This is the mutation-killing check for the computed reserve.)
+    expect(shaped.text.endsWith("before proceeding.**")).toBe(true);
+  });
+
+  it("giant delivered names cannot destroy the pointer — it leads the text, so even the clamp preserves it", async () => {
+    // Round-2 review: with the pointer AFTER the header, 4,000-char names put
+    // the header at 12,127 chars and the clamp sliced the pointer off
+    // entirely — an offload file on disk that nothing tells the model to
+    // read. Skill names have no enforced bound anywhere (portal manifest).
+    const giants = ["G".repeat(4_000), "H".repeat(4_000), "I".repeat(4_000)];
+    const r = await routePrompt("ui/ux", [], deps({
+      resolvePromptSkillNames: async () => giants,
+      entitledNames: async () => new Set(giants),
+      getBody: async () => `# body\n${"x".repeat(6_000)}`,
+    }));
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => "/tmp/prism-test/route-giant.md");
+    expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS); // kills clamp deletion
+    expect(shaped.text.slice(0, 2_048)).toContain("/tmp/prism-test/route-giant.md"); // kills pointer-after-header
+    expect(shaped.text.slice(0, 2_048)).toMatch(/Read that file now/i);
+  });
+
+  it("moderately long names cannot push the pointer past the 2KB preview window", async () => {
+    // The more reachable round-2 regime: 200-char names (within NAME_MAX),
+    // header 2,372 chars, clamp never fires — yet the trailing pointer sat at
+    // offset ~2,374, past every preview window.
+    const mediums = Array.from({ length: 11 }, (_, i) => `${"m".repeat(196)}${String(i).padStart(3, "0")}`);
+    const r = await routePrompt("ui/ux", [], deps({
+      resolvePromptSkillNames: async () => mediums,
+      entitledNames: async () => new Set(mediums),
+      getBody: async () => `# body\n${"x".repeat(6_000)}`,
+    }));
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => "/tmp/prism-test/route-med.md");
+    expect(shaped.text.slice(0, 2_048)).toContain("/tmp/prism-test/route-med.md");
+  });
+
+  it("the exact-fixpoint reserve does not skip a body that fits — no over-reservation regression", async () => {
+    // Round-2 finding 3: reserving for ALL delivered names (instead of the
+    // actually-skipped set) skipped a body that previously inlined. Geometry:
+    // three long-named skills, third body huge (skipped either way). The
+    // fixpoint reserves only for the ONE skipped name (~263 chars), so the
+    // second body fits; an all-names reserve (~563) would skip it too.
+    const names = [`A${"a".repeat(147)}`, `B${"b".repeat(147)}`, `C${"c".repeat(147)}`];
+    const bodies: Record<string, string> = {
+      [names[0]]: `#1\n${"x".repeat(4_000)}`,
+      [names[1]]: `#2\n${"y".repeat(4_512)}`,
+      [names[2]]: `#3\n${"z".repeat(6_000)}`,
+    };
+    const r = await routePrompt("ui/ux", [], deps({
+      resolvePromptSkillNames: async () => names,
+      entitledNames: async () => new Set(names),
+      getBody: async (n: string) => bodies[n] ?? "",
+    }));
+    const shaped = reshapeForInlineBudget(r, HOOK_INLINE_SAFE_CHARS, () => undefined);
+    expect(shaped.text.length).toBeLessThanOrEqual(HOOK_INLINE_SAFE_CHARS);
+    expect(shaped.text).toContain("y".repeat(100)); // second body INLINED — kills the all-names reserve
+    expect(shaped.text).toContain(`### ${names[1]}`);
+    expect(shaped.text).toMatch(/Not inlined .*C/s); // the huge third is named, not silently gone
+    expect(shaped.text.endsWith("before proceeding.**")).toBe(true); // footer intact under the clamp
   });
 });
 

--- a/tests/verification/first-run-e2e.test.ts
+++ b/tests/verification/first-run-e2e.test.ts
@@ -81,6 +81,11 @@ describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
         HOME: scrubHome,
         USERPROFILE: scrubHome, // Windows equivalent of HOME
         PRISM_SKILL_SYNC_DISABLED: "true",
+        // The spawned server does not inherit VITEST/NODE_ENV, so the hook
+        // self-heal timer would fire inside this child. It is a no-op on a
+        // scrubbed HOME, but a test must not depend on that: disable it
+        // explicitly rather than rely on the absence of host roots.
+        PRISM_DISABLE_HOOK_AUTOINSTALL: "1",
         PRISM_DASHBOARD_PORT: String(foreignPort),
       },
     });


### PR DESCRIPTION
Third adversarial pass over the merged mid-session routing, new lenses: cross-platform packaging, rollback, abuse, contention.

## Found and fixed

**1. The next release would have failed `npm install` for every Windows consumer.** `"node dist/postinstall.js >/dev/null 2>&1 || true"` — cmd.exe treats `>/dev/null` as a file path that errors and has no `true` builtin. Also exits 1 in this repo's own `npm ci` before `dist` exists. Now a pure-node one-liner (`import(...).catch(()=>{})`) — verified rc=0 with dist present **and** absent.

**2. Self-healing was self-reinfecting.** Remove the hook entry and the next upgrade silently re-adds it — three install paths all "heal". `{"disabled": true}` in the managed marker is now a durable off switch across every path including version bumps, pinned by a test.

**3. Unbounded regex input.** The CLI matches only the first 100k chars of a prompt — pasted logs can be megabytes.

## Measured

`route-prompt` held **0.49–0.52s** while a writer hammered the same settings DB with 2KB writes for 6 seconds — no lock amplification on the per-prompt path, under contention rather than idle.

## Reviewed and deliberately NOT changed

- **Turn-1 double injection** (bootstrap + hook may inject the same skill once): a skip-first-call heuristic would swallow the first mid-session match in every **pre-existing** session — the exact case this feature was built for. Bounded cost, wrong fix available, documented instead.
- **State-dir growth**: one ~100-byte file per session. Cosmetic.
- **Codex hook trust**: their consent gate; one interactive approval per machine, not ours to automate.

86 hook-suite tests; full run **3,895** green.