### PR TITLE
fix(browser): a screenshot must be evidence of what rendered

### DIFF
--- a/scripts/dev/browse.py
+++ b/scripts/dev/browse.py
@@ -1259,6 +1259,22 @@ def _enforce_max_edge(path, max_edge):
     try:
         import shutil as _shutil, subprocess as _subprocess
         if _shutil.which("sips"):
+            # `sips -Z` resamples in BOTH directions — it UPSCALES an image that
+            # is already smaller than max_edge. Unguarded, every macOS capture
+            # came out at exactly the cap on its long edge: a 1440x900 viewport
+            # was written as 1900x1187 and a 1920x1280 one as 1900x1266. That is
+            # not evidence of what rendered, and it breaks any acceptance gate
+            # that asserts a capture is viewport-bound. Measure first and only
+            # shrink when the image genuinely exceeds the cap — the Pillow branch
+            # below already guards this way.
+            probe = _subprocess.run(
+                ["sips", "-g", "pixelWidth", "-g", "pixelHeight", str(path)],
+                capture_output=True, timeout=30, text=True)
+            edges = [int(part.split(":")[1].strip())
+                     for part in probe.stdout.splitlines()
+                     if "pixelWidth:" in part or "pixelHeight:" in part]
+            if edges and max(edges) <= max_edge:
+                return None
             _subprocess.run(["sips", "-Z", str(max_edge), str(path)],
                             capture_output=True, timeout=30, check=True)
             return None
@@ -1306,11 +1322,15 @@ def cmd_screenshot(session, output=None, cleanup=False, full_page=True, selector
     # oversized capture early in a session poisons every later attach — the
     # agent that must LOOK at screenshots loses the ability to see them,
     # mid-conversation, permanently. Full-page captures routinely exceed
-    # 2000px in height, so every capture is normalized to a 1900px long edge
-    # here, at the source. sips is macOS-only; elsewhere we fall back to
-    # Pillow if present and otherwise WARN LOUDLY rather than emit poison
-    # silently.
-    _downscale_warning = _enforce_max_edge(path, 1900)
+    # 2000px in height, so oversized captures are shrunk here, at the source.
+    # sips is macOS-only; elsewhere we fall back to Pillow if present and
+    # otherwise WARN LOUDLY rather than emit poison silently.
+    #
+    # 2000, not 1900: the API limit quoted above is 2000px per dimension, and a
+    # 1900 cap sits just under the standard 1920-wide desktop viewport — so the
+    # single most common UI-evidence capture was resampled to 1900x1266 for no
+    # benefit, failing every gate that asserts a capture is viewport-bound.
+    _downscale_warning = _enforce_max_edge(path, 2000)
 
     size = path.stat().st_size
     audit_log("screenshot", str(path), f"size={size},ephemeral={cleanup}")

--- a/tests/browser-cli.test.ts
+++ b/tests/browser-cli.test.ts
@@ -847,3 +847,78 @@ describe.skipIf(!python || !browserRoot || !firstExternalIPv4())(
     }, 70_000);
   },
 );
+
+describe.skipIf(!python)('screenshot cap is viewport-bound, not viewport-normalizing', () => {
+  // Regression, 2026-08-13: `_enforce_max_edge` shelled straight to `sips -Z`,
+  // which resamples in BOTH directions. Every macOS capture came out at exactly
+  // the cap on its long edge — a 1440x900 viewport was written as 1900x1187 —
+  // so a screenshot asserted as viewport-bound was not evidence of what
+  // rendered, and every acceptance gate built on that assertion was reading a
+  // resampled image. The Pillow branch had always guarded correctly; only the
+  // sips branch upscaled.
+  //
+  // These tests probe pixel dimensions through the same path the fix uses, so
+  // they fail on the pre-fix code (which upscales the small PNG to the cap)
+  // and pass after it.
+  function writePng(dir: string, name: string, width: number, height: number): string {
+    const path = join(dir, name);
+    const result = runPython([
+      'from PIL import Image',
+      `Image.new("RGB", (${width}, ${height}), (10, 20, 30)).save(${JSON.stringify(path)})`,
+      'print("ok")',
+    ].join('\n'));
+    if (result.status !== 0) return '';   // Pillow absent — caller skips
+    return path;
+  }
+
+  function dimensions(path: string): [number, number] {
+    const probe = runPython([
+      'from PIL import Image',
+      `im = Image.open(${JSON.stringify(path)})`,
+      'print(json.dumps(list(im.size)))',
+    ].join('\n'));
+    return JSON.parse(probe.stdout.trim()) as [number, number];
+  }
+
+  it('leaves an already-small capture byte-identical', () => {
+    const dir = makeTempDir('prism-capture-small-');
+    const path = writePng(dir, 'small.png', 1440, 900);
+    if (!path) return;                    // no Pillow in this runtime
+
+    const before = statSync(path).size;
+    const run = runPython([
+      `warning = browse._enforce_max_edge(${JSON.stringify(path)}, 2000)`,
+      'print(json.dumps({"warning": warning}))',
+    ].join('\n'));
+    expect(run.status, run.stderr).toBe(0);
+
+    // The assertion that would have caught the original bug: a sub-cap image
+    // must come back untouched, not resampled to the cap.
+    expect(dimensions(path)).toEqual([1440, 900]);
+    expect(statSync(path).size).toBe(before);
+  });
+
+  it('still shrinks a genuinely oversized capture', () => {
+    const dir = makeTempDir('prism-capture-big-');
+    const path = writePng(dir, 'big.png', 1200, 3000);
+    if (!path) return;
+
+    const run = runPython([
+      `warning = browse._enforce_max_edge(${JSON.stringify(path)}, 2000)`,
+      'print(json.dumps({"warning": warning}))',
+    ].join('\n'));
+    expect(run.status, run.stderr).toBe(0);
+
+    const [width, height] = dimensions(path);
+    expect(Math.max(width, height)).toBeLessThanOrEqual(2000);
+    expect(width).toBeLessThan(1200);     // proportional, not cropped
+  });
+
+  it('caps at 2000 so a 1920-wide desktop viewport is never resampled', () => {
+    // 1900 sat just under the standard 1920 desktop width, so the most common
+    // UI-evidence capture was the one guaranteed to be rewritten.
+    const source = readFileSync(scriptPath, 'utf8');
+    expect(source).toMatch(/_enforce_max_edge\(path,\s*2000\)/);
+    expect(source).not.toMatch(/_enforce_max_edge\(path,\s*1900\)/);
+  });
+});


### PR DESCRIPTION
## The bug

`_enforce_max_edge` shelled straight to `sips -Z`, which resamples in **both** directions — it upscales an image that is already smaller than the cap.

Every macOS capture therefore came out at exactly the cap on its long edge:

| viewport | written as |
|---|---|
| 1440×900 | 1900×1187 |
| 1920×1280 | 1900×1266 |

A capture asserted as viewport-bound was **not evidence of what rendered**, and every acceptance gate built on that assertion had been reading a resampled image. The Pillow branch had always guarded correctly; only the sips branch upscaled.

## The fix

Two halves:

1. **Measure first** — probe `pixelWidth`/`pixelHeight` and return early when the image is already under the cap. Shrink only when it genuinely exceeds it.
2. **Cap 1900 → 2000.** The API limit quoted in the comment directly above the call site is 2000px per dimension. 1900 sat just under the standard 1920-wide desktop viewport, so the single most common UI-evidence capture was the one guaranteed to be rewritten, for no benefit.

## Evidence

Regression tests probe pixel dimensions through the same path the fix uses.

**Pre-fix**, the small-capture test fails with the upscale reproduced exactly:

```
× leaves an already-small capture byte-identical
  → expected [ 2000, 1250 ] to deeply equal [ 1440, 900 ]
× caps at 2000 so a 1920-wide desktop viewport is never resampled
```

**Post-fix**: 32/32 in `tests/browser-cli.test.ts`.

Oversized captures still shrink proportionally — that test passes in both states, which is the point: the change narrows behaviour to shrink-only, it does not disable the cap.

## Not verified

End-to-end capture through a live Chromium could not run in my environment (browser launch fails with SIGTRAP, unrelated to this change). The same two-part patch was separately verified end-to-end at 1:1 on 1440×900, 1920×1280 and 390×844 before this PR was raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)