### PR TITLE
fix(resolver): a memory product must never refuse the write

### DIFF
--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -593,26 +593,19 @@ export async function sessionSaveLedgerHandler(args: unknown) {
 
   const storage = await getStorage();
 
-  // ─── Project mismatch validation (v13 — hard-rejects on mismatch) ───
-  // Replaces the old soft-warning behavior that allowed cross-project
-  // writes. See projectResolver.ts for the lookup logic.
+  // ─── Project validation (v14 — warns, NEVER refuses the write) ───
+  // v13 hard-rejected on mismatch, trusting auto-created registry rows that
+  // turned out to be junk on a live machine (home-dir and relative-path
+  // entries) — agents got contradictory rejections and sessions ended
+  // UNSAVED. A memory product must not drop data to enforce taxonomy.
   let resolverNote = "";
   const resolved = await resolveProject(project, files_changed);
-  if (!resolved.ok) {
-    return {
-      content: [{
-        type: "text",
-        text:
-          `❌ ${resolved.error}\n` +
-          (resolved.hint ? `Hint: ${resolved.hint}\n` : "") +
-          `\nNo ledger entry was written. Re-issue the call with the correct project.`,
-      }],
-      isError: true,
-    };
-  }
   project = resolved.project;
+  if (resolved.warning) {
+    resolverNote = `\n⚠️ ${resolved.warning}`;
+  }
   if (resolved.autoCreated) {
-    resolverNote = `\n📝 Auto-registered project "${project}" with repo_path derived from files_changed.`;
+    resolverNote += `\n📝 Auto-registered project "${project}" with repo_path derived from files_changed.`;
   }
 
   debugLog(`[session_save_ledger] Saving ledger entry for project="${project}"`);

--- a/src/utils/projectResolver.ts
+++ b/src/utils/projectResolver.ts
@@ -24,15 +24,14 @@ export interface ResolveOk {
   ok: true;
   project: string;
   autoCreated?: boolean;
+  /** Set when the registry disagrees with the declaration. Advisory only —
+   *  the write proceeds under the DECLARED project. */
+  warning?: string;
 }
 
-export interface ResolveErr {
-  ok: false;
-  error: string;
-  hint?: string;
-}
-
-export type ResolveResult = ResolveOk | ResolveErr;
+/** The resolver never refuses a write (see 2026-08-13 note below); the
+ *  error shape exists only for source compatibility and is never returned. */
+export type ResolveResult = ResolveOk;
 
 const REPO_PATH_PREFIX = "repo_path:";
 
@@ -113,14 +112,23 @@ export async function resolveProject(
   const registry = await loadRegistry();
   const derivedProject = pickFromRegistry(registry, filesChanged);
 
+  // 2026-08-13: this used to HARD-REJECT on mismatch — and the registry it
+  // trusted was auto-created junk (a live machine carried a repo_path entry
+  // pointing at the HOME DIRECTORY, which contains every absolute path, plus
+  // five relative-path rows). Agents got contradictory rejections, ping-ponged
+  // by the hint, and sessions ended UNSAVED — a memory product dropping data to
+  // enforce taxonomy. The declaration now always wins; the derivation is an
+  // advisory warning. (The wrong-project class this gate was built for —
+  // a 2026-04-30 memory-loss incident — is still surfaced, as a warning
+  // the agent sees at save time instead of a refusal the user never does.)
   if (derivedProject && derivedProject !== declaredProject) {
     return {
-      ok: false,
-      error:
-        `Project mismatch: declared "${declaredProject}" but files_changed indicate "${derivedProject}".`,
-      hint:
-        `Re-issue the request with project="${derivedProject}". ` +
-        `If you genuinely intended "${declaredProject}", first add it to the registry with a non-overlapping repo_path.`,
+      ok: true,
+      project: declaredProject,
+      warning:
+        `Registry suggests these files belong to "${derivedProject}", but the entry was saved under ` +
+        `"${declaredProject}" as declared. If "${derivedProject}" is correct, re-save with that project; ` +
+        `if the registry is wrong, its repo_path for "${derivedProject}" needs repair.`,
     };
   }
 
@@ -133,7 +141,7 @@ export async function resolveProject(
   }
 
   const prefix = commonPathPrefix(filesChanged);
-  if (prefix) {
+  if (prefix && isRegistrablePrefix(prefix, registry)) {
     try {
       await setSetting(`${REPO_PATH_PREFIX}${declaredProject}`, prefix);
       debugLog(
@@ -148,4 +156,25 @@ export async function resolveProject(
   }
 
   return { ok: true, project: declaredProject };
+}
+
+/**
+ * Auto-create hygiene, added 2026-08-13. Every class rejected here was FOUND
+ * in a live registry, where it poisoned later saves:
+ *  - relative prefixes ("Tests/UITests") match or miss depending on the path
+ *    style a later save happens to use;
+ *  - short prefixes (a 2-segment home directory) contain every absolute
+ *    path on the machine;
+ *  - an ancestor of an existing entry re-creates the same containment bomb
+ *    one level down.
+ * Refusing to register is safe: the save proceeds either way, and the next
+ * save with a cleaner file list can still register the project.
+ */
+function isRegistrablePrefix(prefix: string, registry: RegistryEntry[]): boolean {
+  if (!prefix.startsWith("/")) return false;
+  if (prefix.split("/").filter(Boolean).length < 3) return false;
+  for (const entry of registry) {
+    if (isUnder(entry.repo_path, prefix)) return false; // ancestor of an existing entry
+  }
+  return true;
 }

--- a/tests/project-resolver.test.ts
+++ b/tests/project-resolver.test.ts
@@ -1,0 +1,96 @@
+/**
+ * projectResolver — the save-path gate that was measured DROPPING data.
+ *
+ * Incident 2026-08-13: session_save_ledger hard-rejected legitimate saves
+ * with contradictory verdicts ("declared X but files indicate Y", then
+ * "declared Y but files indicate Z" on identical input). Root cause on the
+ * live machine's registry: an auto-created row whose repo_path was the HOME
+ * DIRECTORY — every absolute path matches — plus five relative-path rows
+ * ("Tests/UITests", "src/__tests__"). Auto-create wrote junk, the
+ * validator treated junk as authoritative, and the hard-reject turned a
+ * taxonomy heuristic into data loss — in a memory product.
+ *
+ * The contract these tests pin: the resolver NEVER refuses a write, and
+ * auto-create can no longer register junk.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const settings: Record<string, string> = {};
+vi.mock("../src/storage/configStorage.js", () => ({
+  getAllSettings: vi.fn(async () => ({ ...settings })),
+  setSetting: vi.fn(async (k: string, v: string) => { settings[k] = v; }),
+}));
+
+import { resolveProject } from "../src/utils/projectResolver.js";
+
+beforeEach(() => { for (const k of Object.keys(settings)) delete settings[k]; });
+
+describe("a memory product never refuses the write", () => {
+  it("mismatch WARNS and saves under the DECLARED project — never ok:false", async () => {
+    settings["repo_path:other-project"] = "/Users/dev/work/repo";
+    const r = await resolveProject("my-project", ["/Users/dev/work/repo/src/a.ts"]);
+    expect(r.ok).toBe(true);
+    expect(r.project).toBe("my-project"); // the agent's declaration wins
+    expect(r.warning).toMatch(/other-project/); // the heuristic advises
+    expect(r.warning).toMatch(/my-project/);
+  });
+
+  it("a poisoned home-dir registry row cannot hijack saves into a rejection", async () => {
+    // The live poison shape: one entry containing every absolute path.
+    settings["repo_path:catch-all"] = "/Users/dev";
+    const r = await resolveProject("prism-mcp", ["/Users/dev/prism/src/cli.ts"]);
+    expect(r.ok).toBe(true);
+    expect(r.project).toBe("prism-mcp");
+  });
+
+  it("agreement stays clean — no warning", async () => {
+    settings["repo_path:prism-mcp"] = "/Users/dev/prism";
+    const r = await resolveProject("prism-mcp", ["/Users/dev/prism/src/cli.ts"]);
+    expect(r.ok).toBe(true);
+    expect(r.warning).toBeUndefined();
+  });
+
+  it("no files_changed → declared project accepted, nothing registered", async () => {
+    const r = await resolveProject("anything", []);
+    expect(r.ok).toBe(true);
+    expect(Object.keys(settings)).toHaveLength(0);
+  });
+});
+
+describe("auto-create hygiene — the junk that poisoned the live registry", () => {
+  it("never registers a RELATIVE prefix (live junk shape: 'Tests/UITests')", async () => {
+    await resolveProject("coach-app", ["Tests/UITests/a.swift", "Tests/UITests/b.swift"]);
+    expect(settings["repo_path:coach-app"]).toBeUndefined();
+  });
+
+  it("never registers a 2-segment path (live junk shape: a home directory)", async () => {
+    await resolveProject("broad", ["/Users/dev/x.txt", "/Users/dev/y.txt"]);
+    expect(settings["repo_path:broad"]).toBeUndefined();
+  });
+
+  it("never registers an ANCESTOR of an existing entry — one broad row poisons every later save", async () => {
+    settings["repo_path:existing"] = "/Users/dev/work/repo";
+    await resolveProject("umbrella", ["/Users/dev/work/a.txt", "/Users/dev/work/b.txt"]);
+    expect(settings["repo_path:umbrella"]).toBeUndefined();
+  });
+
+  it("still registers a legitimate absolute repo root", async () => {
+    const r = await resolveProject("new-proj", [
+      "/Users/dev/work/new-proj/src/a.ts",
+      "/Users/dev/work/new-proj/src/b.ts",
+    ]);
+    expect(r.ok).toBe(true);
+    expect(r.autoCreated).toBe(true);
+    expect(settings["repo_path:new-proj"]).toBe("/Users/dev/work/new-proj/src");
+  });
+});
+
+describe("derivation semantics preserved", () => {
+  it("longest repo_path wins so nested repos resolve to the nested project", async () => {
+    settings["repo_path:mono"] = "/Users/dev/mono";
+    settings["repo_path:mono-sub"] = "/Users/dev/mono/packages/sub";
+    const r = await resolveProject("mono-sub", ["/Users/dev/mono/packages/sub/x.ts"]);
+    expect(r.ok).toBe(true);
+    expect(r.warning).toBeUndefined(); // nested match agrees with declaration
+  });
+});

--- a/tests/utils/projectResolver.test.ts
+++ b/tests/utils/projectResolver.test.ts
@@ -91,7 +91,7 @@ describe("resolveProject", () => {
     expect(result).toEqual({ ok: true, project: "anything" });
   });
 
-  it("REJECTS the original prism-aac → prism-mcp memory-loss case", async () => {
+  it("WARNS on the original memory-loss case and saves as declared (v14: never refuses)", async () => {
     mockGetAllSettings.mockResolvedValue({
       "repo_path:prism-aac": "/Users/example/prism-aac",
       "repo_path:prism-mcp": "/Users/example/prism",
@@ -102,12 +102,13 @@ describe("resolveProject", () => {
       "/Users/example/prism-aac/services/aiProvider.ts",
     ]);
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('declared "prism-mcp"');
-      expect(result.error).toContain('"prism-aac"');
-      expect(result.hint).toContain('project="prism-aac"');
-    }
+    // 2026-08-13: this used to hard-reject — and live registries turned out to
+    // contain auto-created junk, so the reject was dropping legitimate saves.
+    // The wrong-project signal survives as an advisory warning.
+    expect(result.ok).toBe(true);
+    expect(result.project).toBe("prism-mcp");
+    expect(result.warning).toContain('"prism-aac"');
+    expect(result.warning).toContain('"prism-mcp"');
   });
 
   it("accepts when declared project matches the registry-derived project", async () => {
@@ -176,10 +177,11 @@ describe("resolveProject", () => {
       "/Users/example/prism-aac/src/index.ts",
     ]);
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('"prism-aac"');
-    }
+    // Longest-match derivation is unchanged; since v14 it surfaces as a
+    // warning on the saved-as-declared result instead of a rejection.
+    expect(result.ok).toBe(true);
+    expect(result.project).toBe("monorepo");
+    expect(result.warning).toContain('"prism-aac"');
   });
 
   it("survives setSetting failure during auto-create", async () => {


### PR DESCRIPTION
session_save_ledger hard-rejected legitimate saves on declared-vs-derived project mismatch, and the registry it trusted was auto-created junk (one row's repo_path was the user's home directory — matching every absolute path — plus five relative-path rows). Agents received contradictory rejections and sessions ended UNSAVED.

- `resolveProject` never returns `ok:false`: a mismatch saves under the DECLARED project and returns an advisory warning instead
- auto-create hygiene: only absolute, ≥3-segment prefixes that are not an ancestor of an existing entry can be registered
- `ledgerHandlers` threads the warning into the save confirmation

Proven live over MCP stdio: the previous build rejected the probe save ('No ledger entry was written'); this build saves it and surfaces the warning. 9 new tests (5 written red first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)