### PR TITLE
feat(update): update-available notice by default, scheduled updates by opt-in

### DIFF
--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -1,0 +1,258 @@
+/**
+ * `prism update` / `prism autoupdate` — unattended-safe package updates.
+ *
+ * Why this is NOT `prism connect` on a timer (design review 2026-08-14):
+ * connect writes host configuration and expects hosts to be closed — a
+ * condition no scheduler can guarantee. This module's whole authority is
+ * `npm install -g prism-mcp-server@<latest>`:
+ *   - host configuration, hooks, and hook trust are untouchable from here —
+ *     there is no code path to them;
+ *   - running server processes keep the code they booted with; the next
+ *     process start picks up the new release (global registrations resolve
+ *     through the bin symlink);
+ *   - `--if-idle` defers entirely while any Prism MCP server process is
+ *     alive, and an UNVERIFIABLE process list counts as busy — fail safe;
+ *   - a single-instance lock prevents overlapping npm runs (a scheduler
+ *     firing while an operator updates by hand).
+ *
+ * Configuration migrations stay behind a visible `prism connect` run.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, openSync, closeSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { isNewer } from "./selfUpdate.js";
+
+const PACKAGE = "prism-mcp-server";
+const SEMVER = /^\d+\.\d+\.\d+$/;
+export const AUTOUPDATE_LABEL = "com.synalux.prism.autoupdate";
+
+export interface PackageUpdateDeps {
+  currentVersion: string;
+  /** Fetch the latest published version; throws on network failure. */
+  fetchLatest?: () => string;
+  /** Run the global install; throws on failure. */
+  install?: (version: string) => void;
+  /** Describe running Prism MCP server processes; throws when undeterminable. */
+  listPrismProcesses?: () => string[];
+  /** Take the single-instance lock; null when another update holds it. */
+  acquireLock?: () => (() => void) | null;
+  ifIdle?: boolean;
+  env?: NodeJS.ProcessEnv;
+  log?: (line: string) => void;
+}
+
+export interface PackageUpdateResult {
+  action: "updated" | "current" | "deferred" | "locked" | "failed" | "skipped";
+  detail: string;
+  latest?: string;
+}
+
+function defaultFetchLatest(): string {
+  return execFileSync("npm", ["view", PACKAGE, "version"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  }).trim();
+}
+
+function defaultInstall(version: string): void {
+  execFileSync("npm", ["install", "-g", `${PACKAGE}@${version}`], {
+    stdio: "inherit",
+    timeout: 300_000,
+  });
+}
+
+/** Lines for live Prism MCP server processes. Throws when `ps` is unusable —
+ *  the caller treats that as busy, never as idle. */
+export function defaultListPrismProcesses(): string[] {
+  const out = execFileSync("ps", ["-axo", "pid=,command="], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  return out
+    .split("\n")
+    .filter((line) => /server\.js/.test(line) && /prism/i.test(line))
+    .map((line) => line.trim());
+}
+
+const LOCK_DIR = () => join(homedir(), ".prism-mcp");
+const LOCK_FILE = () => join(LOCK_DIR(), "update.lock");
+
+/** O_EXCL lockfile with stale-holder recovery (dead pid → reclaim once). */
+export function defaultAcquireLock(): (() => void) | null {
+  mkdirSync(LOCK_DIR(), { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(LOCK_FILE(), "wx");
+      writeFileSync(fd, String(process.pid));
+      closeSync(fd);
+      return () => { try { rmSync(LOCK_FILE(), { force: true }); } catch { /* released is released */ } };
+    } catch {
+      try {
+        const holder = parseInt(readFileSync(LOCK_FILE(), "utf8").trim(), 10);
+        if (Number.isInteger(holder)) {
+          try {
+            process.kill(holder, 0); // alive → genuinely locked
+            return null;
+          } catch {
+            rmSync(LOCK_FILE(), { force: true }); // stale → reclaim and retry
+            continue;
+          }
+        }
+        rmSync(LOCK_FILE(), { force: true }); // unreadable holder → reclaim
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+export function runPackageUpdate(deps: PackageUpdateDeps): PackageUpdateResult {
+  const env = deps.env ?? process.env;
+  const log = deps.log ?? (() => {});
+
+  if (env.PRISM_NO_SELF_UPDATE === "1") {
+    return { action: "skipped", detail: "PRISM_NO_SELF_UPDATE=1" };
+  }
+  if ((env.VITEST || env.NODE_ENV === "test") && !deps.fetchLatest) {
+    return { action: "skipped", detail: "test environment" };
+  }
+  if (deps.currentVersion.includes("-")) {
+    return { action: "skipped", detail: `dev build ${deps.currentVersion} — not touching it` };
+  }
+
+  if (deps.ifIdle) {
+    let running: string[];
+    try {
+      running = (deps.listPrismProcesses ?? defaultListPrismProcesses)();
+    } catch (error) {
+      return {
+        action: "deferred",
+        detail: `cannot verify idleness (${error instanceof Error ? error.message.split("\n")[0] : String(error)}) — deferring`,
+      };
+    }
+    if (running.length > 0) {
+      return {
+        action: "deferred",
+        detail: `${running.length} Prism MCP process(es) running — deferred until idle`,
+      };
+    }
+  }
+
+  const release = (deps.acquireLock ?? defaultAcquireLock)();
+  if (!release) {
+    return { action: "locked", detail: "another prism update is already running" };
+  }
+  try {
+    let latest: string;
+    try {
+      latest = (deps.fetchLatest ?? defaultFetchLatest)();
+    } catch (error) {
+      return { action: "failed", detail: `registry unreachable (${error instanceof Error ? error.message.split("\n")[0] : String(error)})` };
+    }
+    if (!SEMVER.test(latest)) {
+      return { action: "failed", detail: `registry returned unexpected version "${latest}"` };
+    }
+    if (!isNewer(deps.currentVersion, latest)) {
+      return { action: "current", detail: `${deps.currentVersion} is current`, latest };
+    }
+    log(`prism ${deps.currentVersion} → ${latest}: updating the global package …`);
+    try {
+      (deps.install ?? defaultInstall)(latest);
+    } catch (error) {
+      return { action: "failed", detail: `npm install -g failed (${error instanceof Error ? error.message.split("\n")[0] : String(error)})`, latest };
+    }
+    return { action: "updated", detail: `global package now ${latest}; running servers pick it up on their next start`, latest };
+  } finally {
+    release();
+  }
+}
+
+// ─── LaunchAgent (macOS) scheduling ──────────────────────────────
+
+export function autoupdatePlistPath(): string {
+  return join(homedir(), "Library", "LaunchAgents", `${AUTOUPDATE_LABEL}.plist`);
+}
+
+/** Daily 03:30 local, catch-up on wake (LaunchAgents coalesce missed runs). */
+export function buildAutoupdatePlist(prismBin: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${AUTOUPDATE_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${prismBin}</string>
+    <string>update</string>
+    <string>--if-idle</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>3</integer>
+    <key>Minute</key><integer>30</integer>
+  </dict>
+  <key>StandardOutPath</key><string>/tmp/${AUTOUPDATE_LABEL}.log</string>
+  <key>StandardErrorPath</key><string>/tmp/${AUTOUPDATE_LABEL}.log</string>
+</dict>
+</plist>
+`;
+}
+
+export interface AutoupdateStatus {
+  supported: boolean;
+  enabled: boolean;
+  plistPath: string;
+  detail: string;
+}
+
+export function autoupdateStatus(): AutoupdateStatus {
+  const plistPath = autoupdatePlistPath();
+  if (process.platform !== "darwin") {
+    return { supported: false, enabled: false, plistPath, detail: "scheduled updates are macOS-only for now (LaunchAgent)" };
+  }
+  const enabled = existsSync(plistPath);
+  return {
+    supported: true,
+    enabled,
+    plistPath,
+    detail: enabled ? `enabled — daily 03:30, log: /tmp/${AUTOUPDATE_LABEL}.log` : "disabled",
+  };
+}
+
+/** Resolve the `prism` bin the LaunchAgent should run. Warns (does not
+ *  refuse) when it resolves outside node_modules — a checkout CLI still
+ *  updates the global package, but the operator should know which code
+ *  their scheduler runs. */
+export function resolvePrismBin(log: (line: string) => void): string {
+  const bin = execFileSync("which", ["prism"], { encoding: "utf8", timeout: 5_000 }).trim();
+  if (!bin) throw new Error("`prism` not found on PATH — install with: npm install -g prism-mcp-server");
+  try {
+    const real = execFileSync("readlink", ["-f", bin], { encoding: "utf8", timeout: 5_000 }).trim();
+    if (real && !real.includes("node_modules")) {
+      log(`⚠ ${bin} resolves to a source checkout (${real}); the scheduled update will run that CLI (it still updates only the global package)`);
+    }
+  } catch { /* readlink unavailable — proceed with the raw path */ }
+  return bin;
+}
+
+export function enableAutoupdate(log: (line: string) => void): AutoupdateStatus {
+  if (process.platform !== "darwin") return autoupdateStatus();
+  const plistPath = autoupdatePlistPath();
+  const bin = resolvePrismBin(log);
+  mkdirSync(join(homedir(), "Library", "LaunchAgents"), { recursive: true });
+  writeFileSync(plistPath, buildAutoupdatePlist(bin));
+  // Reload cleanly whether or not a previous generation was loaded.
+  try { execFileSync("launchctl", ["unload", plistPath], { timeout: 10_000, stdio: "ignore" }); } catch { /* not loaded */ }
+  execFileSync("launchctl", ["load", "-w", plistPath], { timeout: 10_000 });
+  return autoupdateStatus();
+}
+
+export function disableAutoupdate(): AutoupdateStatus {
+  if (process.platform !== "darwin") return autoupdateStatus();
+  const plistPath = autoupdatePlistPath();
+  try { execFileSync("launchctl", ["unload", plistPath], { timeout: 10_000, stdio: "ignore" }); } catch { /* not loaded */ }
+  rmSync(plistPath, { force: true });
+  return autoupdateStatus();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -208,6 +208,51 @@ program
   .command('browser')
   .description('Run the packaged local Prism Browser automation CLI');
 
+// ─── prism update / prism autoupdate ──────────────────────────
+// Unattended-safe package updates. Deliberately NOT connect-on-a-timer:
+// connect writes host configuration and expects hosts to be closed, which
+// a scheduler cannot guarantee. `update` touches only the global npm
+// package; running servers pick the release up on their next start.
+
+program
+  .command('update')
+  .description('Update the global prism-mcp-server package (never touches host configuration)')
+  .option('--if-idle', 'Only update while no Prism MCP server process is running (scheduler-safe)')
+  .action(async (options: { ifIdle?: boolean }) => {
+    const { runPackageUpdate } = await import('./autoUpdate.js');
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+    const result = runPackageUpdate({
+      currentVersion: pkg.version,
+      ifIdle: options.ifIdle,
+      log: (l) => console.log(l),
+    });
+    console.log(`${result.action}: ${result.detail}`);
+    process.exit(result.action === 'failed' ? 1 : 0);
+  });
+
+program
+  .command('autoupdate <action>')
+  .description('Scheduled daily `prism update --if-idle` — enable | disable | status (opt-in, macOS)')
+  .action(async (action: string) => {
+    const { enableAutoupdate, disableAutoupdate, autoupdateStatus } = await import('./autoUpdate.js');
+    const log = (l: string) => console.log(l);
+    let status;
+    if (action === 'enable') status = enableAutoupdate(log);
+    else if (action === 'disable') status = disableAutoupdate();
+    else if (action === 'status') status = autoupdateStatus();
+    else {
+      console.error(`unknown action "${action}" — use enable, disable, or status`);
+      process.exit(1);
+    }
+    if (!status.supported) {
+      console.log(`− ${status.detail}`);
+      process.exit(action === 'status' ? 0 : 1);
+    }
+    console.log(status.enabled
+      ? `✓ autoupdate ${status.detail}\n  agent: ${status.plistPath}`
+      : `− autoupdate ${status.detail}`);
+  });
+
 // ─── prism connect ────────────────────────────────────────────
 // Registers this installed package with supported MCP hosts. The
 // merge is additive: an existing `prism` or `prism-mcp` entry is

--- a/src/server.ts
+++ b/src/server.ts
@@ -1452,15 +1452,21 @@ export async function startServer() {
   const skillManifestRefresh = setInterval(runSkillManifestSync, 5 * 60 * 1000);
   skillManifestRefresh.unref();
 
-  // Update-check refresh: fire-and-forget AFTER the transport is up, so the
-  // registry ping is never on the prompt-critical path. session_bootstrap
-  // renders from the persisted cache only; the 24h TTL inside refresh keeps
-  // short-lived spawns (codex exec) from pinging npm per run.
-  void (async () => {
-    const { refreshUpdateCache } = await import("./updateNotice.js");
-    const { getSetting, setSetting } = await import("./storage/configStorage.js");
-    await refreshUpdateCache({ getSetting, setSetting });
-  })().catch(() => { /* offline is silent by contract */ });
+  // Update-check refresh: 30s AFTER startup on an unref'd timer, so the
+  // registry ping is never on the prompt-critical path and never interleaves
+  // with first-boot storage initialization (a boot-time kick raced the
+  // first-run demo seed on CI — same-instant sqlite init from two paths).
+  // Short-lived spawns (codex exec) exit before the timer fires and never
+  // ping npm; long-lived hosts refresh 30s in, ample for a 24h TTL.
+  // session_bootstrap renders from the persisted cache only.
+  const updateCheckTimer = setTimeout(() => {
+    void (async () => {
+      const { refreshUpdateCache } = await import("./updateNotice.js");
+      const { getSetting, setSetting } = await import("./storage/configStorage.js");
+      await refreshUpdateCache({ getSetting, setSetting });
+    })().catch(() => { /* offline is silent by contract */ });
+  }, 30_000);
+  updateCheckTimer.unref();
 
   // Register graceful shutdown handlers (SIGTERM, SIGINT, SIGHUP, stdin close).
   // The stdin close handler is critical — when MCP clients disconnect, they

--- a/src/server.ts
+++ b/src/server.ts
@@ -1452,6 +1452,16 @@ export async function startServer() {
   const skillManifestRefresh = setInterval(runSkillManifestSync, 5 * 60 * 1000);
   skillManifestRefresh.unref();
 
+  // Update-check refresh: fire-and-forget AFTER the transport is up, so the
+  // registry ping is never on the prompt-critical path. session_bootstrap
+  // renders from the persisted cache only; the 24h TTL inside refresh keeps
+  // short-lived spawns (codex exec) from pinging npm per run.
+  void (async () => {
+    const { refreshUpdateCache } = await import("./updateNotice.js");
+    const { getSetting, setSetting } = await import("./storage/configStorage.js");
+    await refreshUpdateCache({ getSetting, setSetting });
+  })().catch(() => { /* offline is silent by contract */ });
+
   // Register graceful shutdown handlers (SIGTERM, SIGINT, SIGHUP, stdin close).
   // The stdin close handler is critical — when MCP clients disconnect, they
   // often just close the pipe without sending a signal, leaving zombie processes.

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -35,7 +35,21 @@ import { getSetting, setSetting, getAllSettings, refreshConfigStorageCache } fro
 import { MATERIALIZED_GENERATION_KEY, type SkillSyncResult } from "../skillManifestSync.js";
 import { mergeHandoff, dbToHandoffSchema, sanitizeForMerge } from "../utils/crdtMerge.js";
 import { resolveProject } from "../utils/projectResolver.js";
+import { getUpdateNotice } from "../updateNotice.js";
 import type { StorageBackend } from "../storage/interface.js";
+
+// The running server's own version, for the update-available notice. A read
+// failure must never affect startup: an empty string fails the notice's
+// semver gate, so no notice renders rather than a bogus "running 0.0.0".
+const SERVER_PACKAGE_VERSION: string = (() => {
+  try {
+    return JSON.parse(
+      fs.readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ).version ?? "";
+  } catch {
+    return "";
+  }
+})();
 import {
   isRecoverableStartupStorageError,
   LOCAL_STARTUP_FALLBACK_NOTICE,
@@ -2298,7 +2312,17 @@ export async function sessionBootstrapHandler(
     ? `👋 Welcome to Prism — first run detected. Let's get you productive in a few minutes.`
     : `👋 Welcome back, ${greetingName}. Prism is loading ${depth} context.`;
   const identityBlock = `- 🤖 **Agent Identity:** ${escapeNativeMarkdown(compactWithOmissionCount(role, 80))} — ${greetingName}`;
-  const startupHeader = isFirstRun ? greeting : `${greeting}\n\n${identityBlock}`;
+  // Cache-only by contract: server startup refreshes the cache asynchronously;
+  // this call never touches the npm registry. First run skips the notice — a
+  // just-installed machine is current, and that screen is action-first.
+  const updateNotice = isFirstRun ? "" : await getUpdateNotice({
+    currentVersion: SERVER_PACKAGE_VERSION,
+    getSetting,
+    runningFrom: process.argv[1],
+  });
+  const startupHeader = isFirstRun
+    ? greeting
+    : `${greeting}\n\n${identityBlock}${updateNotice ? `\n${updateNotice}` : ""}`;
 
   if (projects.length === 0) {
     const dashboardUrl = await readDashboardUrl();

--- a/src/updateNotice.ts
+++ b/src/updateNotice.ts
@@ -1,0 +1,128 @@
+/**
+ * Update-available notice — the trigger half of self-update.
+ *
+ * `prism connect` can converge a machine to the latest release, but nothing
+ * ever *ran* it: no launch agent, cron, or background updater exists, so
+ * releases only reached machines whose operator happened to re-run connect.
+ * The notice closes that gap at the only place every user reliably looks —
+ * the first turn of a session.
+ *
+ * Split enforced by design review (2026-08-14):
+ *  - `getUpdateNotice` is CACHE-ONLY. It runs on the prompt-critical path
+ *    (session_bootstrap) and must never touch the npm registry.
+ *  - `refreshUpdateCache` is the async half. Server startup kicks it
+ *    fire-and-forget after initialization; it respects a 24-hour TTL so a
+ *    machine pings the registry at most once a day no matter how many
+ *    short-lived server processes spawn (codex exec starts one per run).
+ *  - Offline is silent. A registry answer that is not plain semver is
+ *    discarded, never cached, never rendered — the cached value ends up
+ *    inside model-facing markdown, so it is validated on write AND on read.
+ */
+import { execFile } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { isNewer } from "./selfUpdate.js";
+
+export const UPDATE_CHECK_KEY = "update_check";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const SEMVER = /^\d+\.\d+\.\d+$/;
+const PACKAGE = "prism-mcp-server";
+
+interface CacheShape {
+  checked_at?: number;
+  latest?: string;
+}
+
+async function readCache(
+  getSetting: (key: string, fallback: string) => Promise<string>,
+): Promise<CacheShape> {
+  try {
+    const parsed = JSON.parse(await getSetting(UPDATE_CHECK_KEY, "{}"));
+    return typeof parsed === "object" && parsed !== null ? parsed as CacheShape : {};
+  } catch {
+    return {};
+  }
+}
+
+function cacheIsFresh(cache: CacheShape, now: () => number): boolean {
+  return typeof cache.checked_at === "number" &&
+    now() - cache.checked_at < CACHE_TTL_MS &&
+    now() - cache.checked_at >= 0; // a future timestamp is corruption, not freshness
+}
+
+export interface UpdateNoticeDeps {
+  currentVersion: string;
+  getSetting: (key: string, fallback: string) => Promise<string>;
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+  /** Path this server is executing from (process.argv[1]); a path outside
+   *  node_modules is a source checkout, where plain `prism connect` leaves
+   *  the registration untouched and the right command is `--refresh`. */
+  runningFrom?: string;
+}
+
+/** Cache-only: renders the notice line, or "" — never touches the network. */
+export async function getUpdateNotice(deps: UpdateNoticeDeps): Promise<string> {
+  const env = deps.env ?? process.env;
+  if (env.PRISM_NO_UPDATE_CHECK === "1") return "";
+  // A caller that could not determine its own version renders nothing —
+  // a comparison against "" or "0.0.0" would call every release an update.
+  if (!SEMVER.test(deps.currentVersion)) return "";
+  const now = deps.now ?? Date.now;
+  const cache = await readCache(deps.getSetting);
+  if (!cacheIsFresh(cache, now)) return "";
+  const latest = typeof cache.latest === "string" && SEMVER.test(cache.latest) ? cache.latest : "";
+  if (!latest || !isNewer(deps.currentVersion, latest)) return "";
+
+  let fromCheckout = false;
+  if (deps.runningFrom) {
+    let resolved = deps.runningFrom;
+    try { resolved = realpathSync(deps.runningFrom); } catch { /* keep raw */ }
+    fromCheckout = !resolved.includes("node_modules");
+  }
+  const command = fromCheckout ? "prism connect --refresh" : "prism connect";
+  return `- ⬆️ **Update available:** Prism ${latest} (running ${deps.currentVersion}) — run \`${command}\``;
+}
+
+export interface RefreshDeps {
+  getSetting: (key: string, fallback: string) => Promise<string>;
+  setSetting: (key: string, value: string) => Promise<void>;
+  fetchLatest?: () => Promise<string>;
+  now?: () => number;
+  env?: NodeJS.ProcessEnv;
+}
+
+function defaultFetchLatest(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      "npm", ["view", PACKAGE, "version"],
+      { encoding: "utf8", timeout: 10_000 },
+      (error, stdout) => (error ? reject(error) : resolve(stdout.trim())),
+    );
+    // A short-lived server process (codex exec) must be able to exit without
+    // waiting on this check.
+    child.unref?.();
+  });
+}
+
+/** Async half: refresh the persisted cache when the TTL has lapsed.
+ *  Never throws — offline machines boot silently. */
+export async function refreshUpdateCache(deps: RefreshDeps): Promise<void> {
+  const env = deps.env ?? process.env;
+  if (env.PRISM_NO_UPDATE_CHECK === "1") return;
+  if (env.VITEST || env.NODE_ENV === "test") {
+    // Test runners never reach the network — same rule as self-update —
+    // EXCEPT through an explicitly injected fetcher, which is the test.
+    if (!deps.fetchLatest) return;
+  }
+  const now = deps.now ?? Date.now;
+  try {
+    const cache = await readCache(deps.getSetting);
+    if (cacheIsFresh(cache, now)) return;
+    const latest = (await (deps.fetchLatest ?? defaultFetchLatest)()).trim();
+    if (!SEMVER.test(latest)) return;
+    await deps.setSetting(UPDATE_CHECK_KEY, JSON.stringify({ checked_at: now(), latest }));
+  } catch {
+    // Offline, registry down, npm missing: silence. The notice simply
+    // does not render until a later successful check.
+  }
+}

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `prism update` — the scheduled-safe package updater.
+ *
+ * Design review 2026-08-14: a timer must NOT run `prism connect` — connect
+ * writes host configuration and expects hosts to be closed, which a timer
+ * cannot guarantee. `prism update` therefore:
+ *   - updates ONLY the global npm package (running servers keep their code;
+ *     the next process start picks up the new release)
+ *   - with --if-idle, DEFERS while any Prism MCP server process is running
+ *   - takes a single-instance lock so overlapping runs cannot race npm
+ *   - never touches host configuration, hooks, or hook trust (there is no
+ *     code path to them — asserted here by the deps surface)
+ */
+import { describe, it, expect, vi } from "vitest";
+import { runPackageUpdate, buildAutoupdatePlist, AUTOUPDATE_LABEL } from "../src/autoUpdate.js";
+
+const base = () => ({
+  currentVersion: "20.11.1",
+  fetchLatest: vi.fn(() => "20.12.0"),
+  install: vi.fn(),
+  listPrismProcesses: vi.fn((): string[] => []),
+  acquireLock: vi.fn(() => () => {}),
+  env: {} as NodeJS.ProcessEnv,
+  log: () => {},
+});
+
+describe("runPackageUpdate", () => {
+  it("updates the global package when newer and idle", () => {
+    const deps = base();
+    const result = runPackageUpdate(deps);
+    expect(result.action).toBe("updated");
+    expect(deps.install).toHaveBeenCalledWith("20.12.0");
+  });
+
+  it("reports current without installing when already latest", () => {
+    const deps = { ...base(), fetchLatest: vi.fn(() => "20.11.1") };
+    expect(runPackageUpdate(deps).action).toBe("current");
+    expect(deps.install).not.toHaveBeenCalled();
+  });
+
+  it("--if-idle DEFERS while any Prism MCP process runs — never installs under a live server", () => {
+    const deps = {
+      ...base(),
+      ifIdle: true,
+      listPrismProcesses: vi.fn(() => ["1234 node /x/prism-mcp-server/dist/server.js"]),
+    };
+    const result = runPackageUpdate(deps);
+    expect(result.action).toBe("deferred");
+    expect(deps.install).not.toHaveBeenCalled();
+    expect(deps.fetchLatest).not.toHaveBeenCalled(); // no work at all while busy
+  });
+
+  it("without --if-idle, running servers do not block (explicit foreground update)", () => {
+    const deps = {
+      ...base(),
+      listPrismProcesses: vi.fn(() => ["1234 node /x/dist/server.js"]),
+    };
+    expect(runPackageUpdate(deps).action).toBe("updated");
+  });
+
+  it("--if-idle treats an UNVERIFIABLE process list as busy, not idle", () => {
+    const deps = {
+      ...base(),
+      ifIdle: true,
+      listPrismProcesses: vi.fn((): string[] => { throw new Error("ps unavailable"); }),
+    };
+    const result = runPackageUpdate(deps);
+    expect(result.action).toBe("deferred");
+    expect(deps.install).not.toHaveBeenCalled();
+  });
+
+  it("refuses to run concurrently — a held lock aborts before any npm work", () => {
+    const deps = { ...base(), acquireLock: vi.fn(() => null) };
+    const result = runPackageUpdate(deps);
+    expect(result.action).toBe("locked");
+    expect(deps.fetchLatest).not.toHaveBeenCalled();
+    expect(deps.install).not.toHaveBeenCalled();
+  });
+
+  it("releases the lock on every path, including install failure", () => {
+    const release = vi.fn();
+    const deps = {
+      ...base(),
+      acquireLock: vi.fn(() => release),
+      install: vi.fn(() => { throw new Error("npm exploded"); }),
+    };
+    expect(runPackageUpdate(deps).action).toBe("failed");
+    expect(release).toHaveBeenCalledOnce();
+
+    const release2 = vi.fn();
+    runPackageUpdate({ ...base(), acquireLock: vi.fn(() => release2) });
+    expect(release2).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a non-semver registry answer", () => {
+    const deps = { ...base(), fetchLatest: vi.fn(() => "banana") };
+    expect(runPackageUpdate(deps).action).toBe("failed");
+    expect(deps.install).not.toHaveBeenCalled();
+  });
+
+  it("never downgrades a dev build", () => {
+    const deps = { ...base(), currentVersion: "20.12.0-local.3" };
+    expect(runPackageUpdate(deps).action).toBe("skipped");
+    expect(deps.install).not.toHaveBeenCalled();
+  });
+
+  it("respects PRISM_NO_SELF_UPDATE=1", () => {
+    const deps = { ...base(), env: { PRISM_NO_SELF_UPDATE: "1" } as NodeJS.ProcessEnv };
+    expect(runPackageUpdate(deps).action).toBe("skipped");
+  });
+});
+
+describe("buildAutoupdatePlist", () => {
+  it("schedules `prism update --if-idle` — never connect, never host config", () => {
+    const plist = buildAutoupdatePlist("/usr/local/bin/prism");
+    expect(plist).toContain(AUTOUPDATE_LABEL);
+    expect(plist).toContain("<string>/usr/local/bin/prism</string>");
+    expect(plist).toContain("<string>update</string>");
+    expect(plist).toContain("<string>--if-idle</string>");
+    expect(plist).not.toContain("connect");
+    expect(plist).toContain("StartCalendarInterval");
+  });
+});

--- a/tests/update-notice.test.ts
+++ b/tests/update-notice.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Update-available notice — the missing trigger for self-update.
+ *
+ * 20.11.x shipped self-update *capability* (`prism connect` converges) with no
+ * *trigger*: nothing on any machine runs connect by itself, so releases only
+ * reached machines whose operator happened to re-run it. The notice closes
+ * that: every session's first turn states when a newer release exists.
+ *
+ * Contract pinned here (design review 2026-08-14):
+ *  - the prompt-critical path NEVER touches the npm registry: the notice
+ *    renders from a persisted cache; refresh happens asynchronously and is
+ *    kicked from server startup, not from the bootstrap call
+ *  - 24-hour cache TTL; strict semver validation; offline silence
+ *  - checkout registrations are told `prism connect --refresh` (plain
+ *    `connect` leaves a checkout registration untouched)
+ */
+import { describe, it, expect, vi } from "vitest";
+import { getUpdateNotice, refreshUpdateCache, UPDATE_CHECK_KEY } from "../src/updateNotice.js";
+
+function makeStore(initial: Record<string, string> = {}) {
+  const store = { ...initial };
+  return {
+    store,
+    getSetting: vi.fn(async (k: string, fallback: string) => store[k] ?? fallback),
+    setSetting: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+  };
+}
+
+const NOW = 1_700_000_000_000;
+
+describe("getUpdateNotice — cache-only, never the network", () => {
+  it("shows the notice when the cached latest is newer", async () => {
+    const s = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 1000, latest: "20.12.0" }),
+    });
+    const notice = await getUpdateNotice({
+      currentVersion: "20.11.1",
+      getSetting: s.getSetting,
+      now: () => NOW,
+    });
+    expect(notice).toContain("20.12.0");
+    expect(notice).toContain("20.11.1");
+    expect(notice).toContain("prism connect");
+    expect(notice).not.toContain("--refresh");
+  });
+
+  it("tells checkout registrations to run connect --refresh", async () => {
+    const s = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 1000, latest: "20.12.0" }),
+    });
+    const notice = await getUpdateNotice({
+      currentVersion: "20.11.1",
+      getSetting: s.getSetting,
+      now: () => NOW,
+      runningFrom: "/Users/dev/prism/dist/server.js", // no node_modules → checkout
+    });
+    expect(notice).toContain("prism connect --refresh");
+  });
+
+  it("is silent when current or ahead of the cached latest", async () => {
+    const s = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 1000, latest: "20.11.1" }),
+    });
+    expect(await getUpdateNotice({ currentVersion: "20.11.1", getSetting: s.getSetting, now: () => NOW })).toBe("");
+    expect(await getUpdateNotice({ currentVersion: "20.12.0", getSetting: s.getSetting, now: () => NOW })).toBe("");
+  });
+
+  it("is silent with no cache, an expired cache, corrupt JSON, or a non-semver value", async () => {
+    const empty = makeStore();
+    expect(await getUpdateNotice({ currentVersion: "20.11.1", getSetting: empty.getSetting, now: () => NOW })).toBe("");
+
+    const expired = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 25 * 60 * 60 * 1000, latest: "20.12.0" }),
+    });
+    expect(await getUpdateNotice({ currentVersion: "20.11.1", getSetting: expired.getSetting, now: () => NOW })).toBe("");
+
+    const corrupt = makeStore({ [UPDATE_CHECK_KEY]: "not-json{" });
+    expect(await getUpdateNotice({ currentVersion: "20.11.1", getSetting: corrupt.getSetting, now: () => NOW })).toBe("");
+
+    const evil = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 1000, latest: "20.12.0-**bold**injection" }),
+    });
+    expect(await getUpdateNotice({ currentVersion: "20.11.1", getSetting: evil.getSetting, now: () => NOW })).toBe("");
+  });
+
+  it("renders nothing when the caller's own version is unknown", async () => {
+    const s = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 1000, latest: "20.12.0" }),
+    });
+    expect(await getUpdateNotice({ currentVersion: "", getSetting: s.getSetting, now: () => NOW })).toBe("");
+    expect(await getUpdateNotice({ currentVersion: "0.0.0-dev", getSetting: s.getSetting, now: () => NOW })).toBe("");
+  });
+
+  it("respects PRISM_NO_UPDATE_CHECK=1", async () => {
+    const s = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 1000, latest: "99.0.0" }),
+    });
+    const notice = await getUpdateNotice({
+      currentVersion: "20.11.1",
+      getSetting: s.getSetting,
+      now: () => NOW,
+      env: { PRISM_NO_UPDATE_CHECK: "1" },
+    });
+    expect(notice).toBe("");
+  });
+});
+
+describe("refreshUpdateCache — the async half, kicked at server startup", () => {
+  it("fetches and persists when the cache is stale", async () => {
+    const s = makeStore();
+    const fetchLatest = vi.fn(async () => "20.12.0");
+    await refreshUpdateCache({
+      getSetting: s.getSetting, setSetting: s.setSetting,
+      fetchLatest, now: () => NOW,
+    });
+    expect(fetchLatest).toHaveBeenCalledOnce();
+    expect(JSON.parse(s.store[UPDATE_CHECK_KEY])).toEqual({ checked_at: NOW, latest: "20.12.0" });
+  });
+
+  it("does NOT fetch while the cache is fresh — one registry ping per TTL, not per session", async () => {
+    const s = makeStore({
+      [UPDATE_CHECK_KEY]: JSON.stringify({ checked_at: NOW - 60_000, latest: "20.11.1" }),
+    });
+    const fetchLatest = vi.fn(async () => "20.12.0");
+    await refreshUpdateCache({
+      getSetting: s.getSetting, setSetting: s.setSetting,
+      fetchLatest, now: () => NOW,
+    });
+    expect(fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it("offline = silent: a fetch failure writes nothing and never throws", async () => {
+    const s = makeStore();
+    await expect(refreshUpdateCache({
+      getSetting: s.getSetting, setSetting: s.setSetting,
+      fetchLatest: async () => { throw new Error("ENOTFOUND registry.npmjs.org"); },
+      now: () => NOW,
+    })).resolves.toBeUndefined();
+    expect(s.store[UPDATE_CHECK_KEY]).toBeUndefined();
+  });
+
+  it("rejects a non-semver registry answer instead of caching it", async () => {
+    const s = makeStore();
+    await refreshUpdateCache({
+      getSetting: s.getSetting, setSetting: s.setSetting,
+      fetchLatest: async () => "banana",
+      now: () => NOW,
+    });
+    expect(s.store[UPDATE_CHECK_KEY]).toBeUndefined();
+  });
+
+  it("respects PRISM_NO_UPDATE_CHECK=1 — no fetch at all", async () => {
+    const s = makeStore();
+    const fetchLatest = vi.fn(async () => "20.12.0");
+    await refreshUpdateCache({
+      getSetting: s.getSetting, setSetting: s.setSetting,
+      fetchLatest, now: () => NOW,
+      env: { PRISM_NO_UPDATE_CHECK: "1" },
+    });
+    expect(fetchLatest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes the trigger gap in self-update. Details in the commit message; 22 new tests, live stdio proof of both notice states, real-world idle deferral (7 live servers detected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)