### PR TITLE
fix(connect): converge Prism-managed registrations connect owns; make the scheduler able to run

### DIFF
--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -175,8 +175,28 @@ export function autoupdatePlistPath(): string {
   return join(homedir(), "Library", "LaunchAgents", `${AUTOUPDATE_LABEL}.plist`);
 }
 
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** The PATH a scheduled run needs. launchd hands an agent a minimal
+ *  PATH (/usr/bin:/bin:/usr/sbin:/sbin) that excludes /usr/local/bin and
+ *  /opt/homebrew/bin — where node and npm live on a standard macOS install.
+ *  Measured 2026-08-14: without this the agent died at `env: node: No such
+ *  file or directory` before running a single line of Prism. The directory
+ *  of the interpreter running this code leads, because that is provably the
+ *  node the operator uses. */
+export function schedulerPath(execPath: string = process.execPath): string {
+  const nodeDir = execPath.slice(0, execPath.lastIndexOf("/")) || "/usr/local/bin";
+  const defaults = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+  return [nodeDir, ...defaults.filter((dir) => dir !== nodeDir)].join(":");
+}
+
 /** Daily 03:30 local, catch-up on wake (LaunchAgents coalesce missed runs). */
-export function buildAutoupdatePlist(prismBin: string): string {
+export function buildAutoupdatePlist(prismBin: string, pathEnv: string = schedulerPath()): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -184,10 +204,14 @@ export function buildAutoupdatePlist(prismBin: string): string {
   <key>Label</key><string>${AUTOUPDATE_LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${prismBin}</string>
+    <string>${xmlEscape(prismBin)}</string>
     <string>update</string>
     <string>--if-idle</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>${xmlEscape(pathEnv)}</string>
+  </dict>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key><integer>3</integer>
@@ -213,27 +237,72 @@ export function autoupdateStatus(): AutoupdateStatus {
     return { supported: false, enabled: false, plistPath, detail: "scheduled updates are macOS-only for now (LaunchAgent)" };
   }
   const enabled = existsSync(plistPath);
+  if (!enabled) {
+    return { supported: true, enabled, plistPath, detail: "disabled" };
+  }
+  // 20.12.0 wrote a plist with no PATH. launchd hands an agent
+  // /usr/bin:/bin:/usr/sbin:/sbin, which excludes the directories holding node
+  // and npm on a standard macOS install, so that generation could never run —
+  // and it failed into a log file nobody reads. Say so instead of reporting a
+  // confident "enabled".
+  let healthy = false;
+  try {
+    healthy = readFileSync(plistPath, "utf8").includes("<key>PATH</key>");
+  } catch { /* unreadable — treat as needing repair */ }
   return {
     supported: true,
     enabled,
     plistPath,
-    detail: enabled ? `enabled — daily 03:30, log: /tmp/${AUTOUPDATE_LABEL}.log` : "disabled",
+    detail: healthy
+      ? `enabled — daily 03:30, log: /tmp/${AUTOUPDATE_LABEL}.log`
+      : "enabled but CANNOT RUN (agent has no PATH; node/npm are not on launchd's default) — re-run `prism autoupdate enable` to repair",
   };
 }
 
-/** Resolve the `prism` bin the LaunchAgent should run. Warns (does not
- *  refuse) when it resolves outside node_modules — a checkout CLI still
- *  updates the global package, but the operator should know which code
- *  their scheduler runs. */
-export function resolvePrismBin(log: (line: string) => void): string {
-  const bin = execFileSync("which", ["prism"], { encoding: "utf8", timeout: 5_000 }).trim();
-  if (!bin) throw new Error("`prism` not found on PATH — install with: npm install -g prism-mcp-server");
+/** Resolve the `prism` the scheduler should run.
+ *
+ *  Prefers the npm global bin over `which prism`: the scheduled job must run
+ *  the INSTALLED CLI deterministically, and an interactive PATH can front it
+ *  with a wrapper. On the machine this was written for, `which prism` returns
+ *  a hand-written bash shim that execs the real bin — harmless, but resolving
+ *  it with readlink returns the shim itself, which an earlier version of this
+ *  code then mislabeled "a source checkout". Only a path that positively
+ *  looks like a repo checkout (a dist/ sibling of a package.json, outside
+ *  node_modules) earns the warning now, and it is a warning, never a refusal. */
+export interface BinResolutionDeps {
+  npmPrefix?: () => string;
+  whichPrism?: () => string;
+  readlink?: (path: string) => string;
+  exists?: (path: string) => boolean;
+}
+
+export function resolvePrismBin(log: (line: string) => void, deps: BinResolutionDeps = {}): string {
+  const exists = deps.exists ?? existsSync;
+  let globalBin: string | undefined;
   try {
-    const real = execFileSync("readlink", ["-f", bin], { encoding: "utf8", timeout: 5_000 }).trim();
-    if (real && !real.includes("node_modules")) {
-      log(`⚠ ${bin} resolves to a source checkout (${real}); the scheduled update will run that CLI (it still updates only the global package)`);
+    const prefix = (deps.npmPrefix ?? (() =>
+      execFileSync("npm", ["prefix", "-g"], { encoding: "utf8", timeout: 15_000 })))().trim();
+    if (prefix) {
+      const candidate = join(prefix, "bin", "prism");
+      if (exists(candidate)) globalBin = candidate;
     }
-  } catch { /* readlink unavailable — proceed with the raw path */ }
+  } catch { /* npm unavailable — fall back to PATH lookup */ }
+  if (globalBin) return globalBin;
+
+  let bin = "";
+  try {
+    bin = (deps.whichPrism ?? (() =>
+      execFileSync("which", ["prism"], { encoding: "utf8", timeout: 5_000 })))().trim();
+  } catch { /* not on PATH */ }
+  if (!bin) throw new Error("`prism` not found — install it with: npm install -g prism-mcp-server");
+  let real = bin;
+  try {
+    real = (deps.readlink ?? ((p: string) =>
+      execFileSync("readlink", ["-f", p], { encoding: "utf8", timeout: 5_000 })))(bin).trim() || bin;
+  } catch { /* keep bin */ }
+  if (!real.includes("node_modules") && /\/dist\/[^/]+$/.test(real)) {
+    log(`⚠ ${bin} resolves to a source checkout (${real}); the scheduled job will run that CLI — it still updates only the global package`);
+  }
   return bin;
 }
 

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -256,7 +256,12 @@ export function autoupdateStatus(): AutoupdateStatus {
     plistPath,
     detail: healthy
       ? `enabled — daily 03:30, log: /tmp/${AUTOUPDATE_LABEL}.log`
-      : "enabled but CANNOT RUN (agent has no PATH; node/npm are not on launchd's default) — re-run `prism autoupdate enable` to repair",
+      // Deliberately "may not run", not "cannot": launchd's default PATH does
+      // contain /usr/bin, so an operator whose node lives there is fine. On a
+      // standard install (Homebrew, /usr/local) it never runs. Claiming a
+      // certain failure we have not measured on THIS machine would be the same
+      // overclaim in the other direction.
+      : "enabled, but this agent predates the PATH fix and may not run (launchd's default PATH omits /usr/local/bin and /opt/homebrew/bin) — re-run `prism autoupdate enable` to repair",
   };
 }
 

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -190,7 +190,8 @@ function xmlEscape(value: string): string {
  *  of the interpreter running this code leads, because that is provably the
  *  node the operator uses. */
 export function schedulerPath(execPath: string = process.execPath): string {
-  const nodeDir = execPath.slice(0, execPath.lastIndexOf("/")) || "/usr/local/bin";
+  const lastSlash = execPath.lastIndexOf("/");
+  const nodeDir = lastSlash > 0 ? execPath.slice(0, lastSlash) : "/usr/local/bin";
   const defaults = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
   return [nodeDir, ...defaults.filter((dir) => dir !== nodeDir)].join(":");
 }

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -140,6 +140,24 @@ export function runPackageUpdate(deps: PackageUpdateDeps): PackageUpdateResult {
   if ((env.VITEST || env.NODE_ENV === "test") && !deps.fetchLatest) {
     return { action: "skipped", detail: "test environment" };
   }
+  if (deps.ifIdle) {
+    let running: string[];
+    try {
+      running = (deps.listPrismProcesses ?? defaultListPrismProcesses)();
+    } catch (error) {
+      return {
+        action: "deferred",
+        detail: `cannot verify idleness (${error instanceof Error ? error.message.split("\n")[0] : String(error)}) — deferring`,
+      };
+    }
+    if (running.length > 0) {
+      return {
+        action: "deferred",
+        detail: `${running.length} Prism MCP process(es) running — deferred until idle`,
+      };
+    }
+  }
+
   // The version that matters is the INSTALLED one; the running CLI may be a
   // checkout, a shim, or an older global. Probing shells out to npm, so tests
   // reach it only through an injected dep.
@@ -161,24 +179,6 @@ export function runPackageUpdate(deps: PackageUpdateDeps): PackageUpdateResult {
   }
   if (targetVersion.includes("-")) {
     return { action: "skipped", detail: `dev build ${targetVersion} — not touching it` };
-  }
-
-  if (deps.ifIdle) {
-    let running: string[];
-    try {
-      running = (deps.listPrismProcesses ?? defaultListPrismProcesses)();
-    } catch (error) {
-      return {
-        action: "deferred",
-        detail: `cannot verify idleness (${error instanceof Error ? error.message.split("\n")[0] : String(error)}) — deferring`,
-      };
-    }
-    if (running.length > 0) {
-      return {
-        action: "deferred",
-        detail: `${running.length} Prism MCP process(es) running — deferred until idle`,
-      };
-    }
   }
 
   const release = (deps.acquireLock ?? defaultAcquireLock)();

--- a/src/autoUpdate.ts
+++ b/src/autoUpdate.ts
@@ -28,7 +28,13 @@ const SEMVER = /^\d+\.\d+\.\d+$/;
 export const AUTOUPDATE_LABEL = "com.synalux.prism.autoupdate";
 
 export interface PackageUpdateDeps {
+  /** Version of the CLI process making the request. Used only as a fallback. */
   currentVersion: string;
+  /** Version of the globally INSTALLED package — the artifact this command
+   *  actually updates. Measured 2026-08-14: comparing the running CLI instead
+   *  let `prism update` report "current" from a 20.12.0 checkout while the
+   *  installed package sat at 20.11.1 and never moved. */
+  installedVersion?: () => string;
   /** Fetch the latest published version; throws on network failure. */
   fetchLatest?: () => string;
   /** Run the global install; throws on failure. */
@@ -53,6 +59,22 @@ function defaultFetchLatest(): string {
     encoding: "utf8",
     timeout: 15_000,
   }).trim();
+}
+
+/** Read the version of the globally installed package. npm puts it under
+ *  <prefix>/lib/node_modules on POSIX and <prefix>/node_modules on Windows. */
+function defaultInstalledVersion(): string {
+  const prefix = execFileSync("npm", ["prefix", "-g"], { encoding: "utf8", timeout: 15_000 }).trim();
+  for (const candidate of [
+    join(prefix, "lib", "node_modules", PACKAGE, "package.json"),
+    join(prefix, "node_modules", PACKAGE, "package.json"),
+  ]) {
+    if (existsSync(candidate)) {
+      const version = JSON.parse(readFileSync(candidate, "utf8"))?.version;
+      if (typeof version === "string" && version.trim()) return version.trim();
+    }
+  }
+  return "";
 }
 
 function defaultInstall(version: string): void {
@@ -118,8 +140,27 @@ export function runPackageUpdate(deps: PackageUpdateDeps): PackageUpdateResult {
   if ((env.VITEST || env.NODE_ENV === "test") && !deps.fetchLatest) {
     return { action: "skipped", detail: "test environment" };
   }
-  if (deps.currentVersion.includes("-")) {
-    return { action: "skipped", detail: `dev build ${deps.currentVersion} — not touching it` };
+  // The version that matters is the INSTALLED one; the running CLI may be a
+  // checkout, a shim, or an older global. Probing shells out to npm, so tests
+  // reach it only through an injected dep.
+  let targetVersion = deps.currentVersion;
+  // Test detection must read the REAL process env: suites pass env: {} to
+  // exercise the policy guards, and that would otherwise let this probe shell
+  // out to npm from inside the test run (caught by a 57ms test that suddenly
+  // consulted the machine's actual install).
+  const inTest = Boolean(
+    env.VITEST || env.NODE_ENV === "test" ||
+    process.env.VITEST || process.env.NODE_ENV === "test",
+  );
+  const mayProbe = Boolean(deps.installedVersion) || !inTest;
+  if (mayProbe) {
+    try {
+      const installed = (deps.installedVersion ?? defaultInstalledVersion)().trim();
+      if (installed) targetVersion = installed;
+    } catch { /* not installed / npm unavailable — compare the running version */ }
+  }
+  if (targetVersion.includes("-")) {
+    return { action: "skipped", detail: `dev build ${targetVersion} — not touching it` };
   }
 
   if (deps.ifIdle) {
@@ -154,10 +195,10 @@ export function runPackageUpdate(deps: PackageUpdateDeps): PackageUpdateResult {
     if (!SEMVER.test(latest)) {
       return { action: "failed", detail: `registry returned unexpected version "${latest}"` };
     }
-    if (!isNewer(deps.currentVersion, latest)) {
-      return { action: "current", detail: `${deps.currentVersion} is current`, latest };
+    if (!isNewer(targetVersion, latest)) {
+      return { action: "current", detail: `installed package ${targetVersion} is current`, latest };
     }
-    log(`prism ${deps.currentVersion} → ${latest}: updating the global package …`);
+    log(`prism ${targetVersion} → ${latest}: updating the global package …`);
     try {
       (deps.install ?? defaultInstall)(latest);
     } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,6 +29,7 @@ import {
   migrateLegacyClaudeInstructions,
   migrateLegacyClaudeManagedStartup,
   migrateLegacyClaudeProjectMcp,
+  connectResultLine,
   normalizeHostName,
 } from './connect.js';
 import { runBrowserCli } from './browserCli.js';
@@ -306,19 +307,11 @@ program
       }
 
       for (const result of summary.results) {
-        if (result.status === 'registered') {
-          console.log(`✓ ${result.label}: registered (${result.path})`);
-        } else if (result.status === 'would-register') {
-          console.log(`• ${result.label}: would register (${result.path})`);
-        } else if (result.status === 'refreshed') {
-          console.log(`✓ ${result.label}: Prism-managed entry refreshed (${result.path})`);
-        } else if (result.status === 'would-refresh') {
-          console.log(`• ${result.label}: would refresh Prism-managed entry (${result.path})`);
-        } else if (result.status === 'existing') {
-          console.log(`− ${result.label}: already registered — untouched (${result.path})`);
-        } else {
-          console.error(`✗ ${result.label}: ${result.message || 'registration failed'} (${result.path})`);
+        if (result.status === 'error') {
+          console.error(connectResultLine(result));
           process.exitCode = 1;
+        } else {
+          console.log(connectResultLine(result));
         }
       }
       const connectedClaude = summary.results.some((result) =>

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1509,25 +1509,19 @@ function registerJsonHost(
       ? "prism"
       : undefined;
 
-  if (existingKey) {
-    const existingEntry = mcpServers[existingKey];
-    const startupCompatible = existingKey === "prism-mcp"
-      && isManagedPrismEntry(existingEntry)
-      && isDeepStrictEqual(refreshManagedEntry(existingEntry, entry), existingEntry);
-    if (!refresh || existingKey !== "prism-mcp" || !isManagedPrismEntry(existingEntry)) {
-      return result(definition, "existing", "Prism is already registered; existing entry left untouched", startupCompatible);
-    }
-
-    const refreshedEntry = refreshManagedEntry(existingEntry, entry);
-    if (JSON.stringify(refreshedEntry) === JSON.stringify(existingEntry)) {
-      return result(definition, "existing", "Prism-managed entry is already current", true);
-    }
-    if (dryRun) {
-      return result(definition, "would-refresh", undefined, true);
-    }
-
-    mcpServers[existingKey] = refreshedEntry;
-    config.mcpServers = mcpServers;
+  // Claude Code keeps ADDITIONAL, directory-scoped registrations under
+  // projects["<dir>"].mcpServers, and the scoped one wins for sessions started
+  // in that directory. Refreshing only the top-level entry left those pinned to
+  // a stale server path forever — measured live 2026-08-14 on a machine
+  // carrying three registrations, where `--refresh` converged exactly one and
+  // two directories kept launching an old build indefinitely. Only entries
+  // Prism itself created are eligible, and only under --refresh, so this
+  // cannot reach a hand-rolled entry. Hosts without a `projects` map are
+  // unaffected: the collector returns nothing.
+  const pendingProjects = refresh ? collectProjectScopedRefreshes(config, entry) : [];
+  const scopedCount = pendingProjects.length;
+  const scopedNoun = `${scopedCount} project-scoped ${scopedCount === 1 ? "entry" : "entries"}`;
+  const writeConfig = (status: ConnectStatus, message: string | undefined, compatible: boolean): ConnectResult => {
     try {
       writeTextAtomically(
         writePath,
@@ -1536,18 +1530,52 @@ function registerJsonHost(
         beforeCommit,
         symlinkPath,
       );
-      return result(definition, "refreshed", undefined, true);
+      return result(definition, status, message, compatible);
     } catch (error) {
       return result(definition, "error", error instanceof Error ? error.message : String(error));
     }
+  };
+
+  if (existingKey) {
+    const existingEntry = mcpServers[existingKey];
+    const startupCompatible = existingKey === "prism-mcp"
+      && isManagedPrismEntry(existingEntry)
+      && isDeepStrictEqual(refreshManagedEntry(existingEntry, entry), existingEntry);
+    if (!refresh || existingKey !== "prism-mcp" || !isManagedPrismEntry(existingEntry)) {
+      if (scopedCount === 0) {
+        return result(definition, "existing", "Prism is already registered; existing entry left untouched", startupCompatible);
+      }
+      if (dryRun) {
+        return result(definition, "would-refresh", `top-level entry left untouched; would refresh ${scopedNoun}`, startupCompatible);
+      }
+      applyProjectScopedRefreshes(config, pendingProjects);
+      return writeConfig("refreshed", `top-level entry left untouched; refreshed ${scopedNoun}`, startupCompatible);
+    }
+
+    const refreshedEntry = refreshManagedEntry(existingEntry, entry);
+    const topLevelStale = JSON.stringify(refreshedEntry) !== JSON.stringify(existingEntry);
+    if (!topLevelStale && scopedCount === 0) {
+      return result(definition, "existing", "Prism-managed entry is already current", true);
+    }
+    if (dryRun) {
+      return result(definition, "would-refresh", scopedCount > 0 ? `also ${scopedNoun}` : undefined, true);
+    }
+
+    if (topLevelStale) {
+      mcpServers[existingKey] = refreshedEntry;
+      config.mcpServers = mcpServers;
+    }
+    applyProjectScopedRefreshes(config, pendingProjects);
+    return writeConfig("refreshed", scopedCount > 0 ? `also refreshed ${scopedNoun}` : undefined, true);
   }
 
   if (dryRun) {
-    return result(definition, "would-register", undefined, true);
+    return result(definition, "would-register", scopedCount > 0 ? `also ${scopedNoun}` : undefined, true);
   }
 
   mcpServers["prism-mcp"] = entry;
   config.mcpServers = mcpServers;
+  applyProjectScopedRefreshes(config, pendingProjects);
 
   try {
     writeTextAtomically(
@@ -1903,6 +1931,23 @@ function result(
   };
 }
 
+/** One operator-facing line per host result.
+ *  The `message` a host writer attaches (e.g. "also refreshed 2 project-scoped
+ *  entries") MUST survive to stdout: the earlier printer used canned per-status
+ *  text and dropped it, so a converged directory-scoped registration was
+ *  invisible to the person who asked for it. */
+export function connectResultLine(result: ConnectResult): string {
+  const detail = result.message ? ` — ${result.message}` : "";
+  switch (result.status) {
+    case "registered":     return `✓ ${result.label}: registered${detail} (${result.path})`;
+    case "would-register": return `• ${result.label}: would register${detail} (${result.path})`;
+    case "refreshed":      return `✓ ${result.label}: Prism-managed entry refreshed${detail} (${result.path})`;
+    case "would-refresh":  return `• ${result.label}: would refresh Prism-managed entry${detail} (${result.path})`;
+    case "existing":       return `− ${result.label}: already registered — untouched (${result.path})`;
+    default:               return `✗ ${result.label}: ${result.message || "registration failed"} (${result.path})`;
+  }
+}
+
 function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -1917,6 +1962,45 @@ function isManagedPrismEntry(value: unknown): value is JsonObject {
   return isJsonObject(value)
     && isJsonObject(value.env)
     && value.env.PRISM_INSTANCE === "prism-mcp";
+}
+
+interface PendingProjectRefresh {
+  project: string;
+  entry: JsonObject;
+}
+
+/** Prism-managed, directory-scoped registrations that are out of date.
+ *  Claude Code stores these under projects["<dir>"].mcpServers; other hosts
+ *  have no `projects` map, so this returns nothing for them. */
+function collectProjectScopedRefreshes(config: JsonObject, desired: JsonObject): PendingProjectRefresh[] {
+  const projects = config.projects;
+  if (!isJsonObject(projects)) return [];
+  const pending: PendingProjectRefresh[] = [];
+  for (const [project, projectConfig] of Object.entries(projects)) {
+    if (!isJsonObject(projectConfig)) continue;
+    const servers = projectConfig.mcpServers;
+    if (!isJsonObject(servers)) continue;
+    const existing = servers["prism-mcp"];
+    if (!isManagedPrismEntry(existing)) continue;   // hand-rolled entries stay untouched
+    const refreshed = refreshManagedEntry(existing, desired);
+    if (JSON.stringify(refreshed) !== JSON.stringify(existing)) {
+      pending.push({ project, entry: refreshed });
+    }
+  }
+  return pending;
+}
+
+function applyProjectScopedRefreshes(config: JsonObject, pending: PendingProjectRefresh[]): void {
+  if (pending.length === 0) return;
+  const projects = config.projects;
+  if (!isJsonObject(projects)) return;
+  for (const { project, entry } of pending) {
+    const projectConfig = projects[project];
+    if (!isJsonObject(projectConfig)) continue;
+    const servers = projectConfig.mcpServers;
+    if (!isJsonObject(servers)) continue;
+    servers["prism-mcp"] = entry;
+  }
 }
 
 function refreshManagedEntry(existing: JsonObject, desired: JsonObject): JsonObject {

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -42,15 +42,20 @@ describe("runPackageUpdate", () => {
   });
 
   it("--if-idle DEFERS while any Prism MCP process runs — never installs under a live server", () => {
+    const installedVersion = vi.fn(() => "20.11.1");
     const deps = {
       ...base(),
       ifIdle: true,
+      installedVersion,
       listPrismProcesses: vi.fn(() => ["1234 node /x/prism-mcp-server/dist/server.js"]),
     };
     const result = runPackageUpdate(deps);
     expect(result.action).toBe("deferred");
     expect(deps.install).not.toHaveBeenCalled();
     expect(deps.fetchLatest).not.toHaveBeenCalled(); // no work at all while busy
+    // Ordering matters for a scheduled run: deciding to defer must not shell
+    // out to npm at all (the installed-version probe runs `npm prefix -g`).
+    expect(installedVersion).not.toHaveBeenCalled();
   });
 
   it("without --if-idle, running servers do not block (explicit foreground update)", () => {

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -223,7 +223,10 @@ describe("autoupdateStatus — a plist that cannot run must not report a clean '
       writeFileSync(autoupdatePlistPath(), "<plist><dict><key>Label</key></dict></plist>");
       const status = autoupdateStatus();
       expect(status.enabled).toBe(true);
-      expect(status.detail).toMatch(/CANNOT RUN|repair/);
+      expect(status.detail).toMatch(/may not run/);
+      expect(status.detail).toMatch(/repair/);
+      // Never assert a failure we have not measured on this machine.
+      expect(status.detail).not.toMatch(/CANNOT RUN/);
     } finally {
       if (prev === undefined) delete process.env.HOME; else process.env.HOME = prev;
     }

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -232,3 +232,37 @@ describe("autoupdateStatus — a plist that cannot run must not report a clean '
     }
   });
 });
+
+describe("runPackageUpdate compares the INSTALLED package, not the running CLI", () => {
+  // Measured 2026-08-14 on a real machine: the checkout CLI (20.12.0) reported
+  // "20.12.0 is current" while the globally installed package — the only thing
+  // this command updates — sat at 20.11.1 with 20.12.0 on npm. A command that
+  // reports "current" while the artifact it manages is stale is the same class
+  // of failure this whole feature exists to end.
+  const base = () => ({
+    currentVersion: "20.12.0",          // the CLI you happen to be running
+    installedVersion: () => "20.11.1",  // what is actually installed globally
+    fetchLatest: vi.fn(() => "20.12.0"),
+    install: vi.fn(),
+    acquireLock: vi.fn(() => () => {}),
+    env: {} as NodeJS.ProcessEnv,
+  });
+
+  it("updates when the INSTALLED package is behind, even if the running CLI is current", () => {
+    const deps = base();
+    const result = runPackageUpdate(deps);
+    expect(result.action).toBe("updated");
+    expect(deps.install).toHaveBeenCalledWith("20.12.0");
+  });
+
+  it("falls back to the running version when the installed one cannot be read", () => {
+    const deps = { ...base(), installedVersion: () => { throw new Error("not installed"); } };
+    expect(runPackageUpdate(deps).action).toBe("current");
+  });
+
+  it("applies the dev-build guard to the INSTALLED version", () => {
+    const deps = { ...base(), installedVersion: () => "20.13.0-local.2" };
+    expect(runPackageUpdate(deps).action).toBe("skipped");
+    expect(deps.install).not.toHaveBeenCalled();
+  });
+});

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -154,7 +154,8 @@ describe("resolvePrismBin — which CLI the scheduler runs", () => {
       whichPrism: () => "/Users/dev/bin/prism\n",
       exists: () => true,
     });
-    expect(bin).toBe("/Users/dev/.npm-global/bin/prism");
+    // join() is platform-native: the Windows runner produces backslashes.
+    expect(bin).toBe(join("/Users/dev/.npm-global", "bin", "prism"));
     expect(warnings).toEqual([]);
   });
 

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -196,6 +196,16 @@ describe("schedulerPath", () => {
   it("covers a Homebrew-ARM node too", () => {
     expect(schedulerPath("/opt/homebrew/bin/node").startsWith("/opt/homebrew/bin:")).toBe(true);
   });
+
+  it("never derives a garbage directory from a slashless interpreter path", () => {
+    // Review catch: lastIndexOf("/") === -1 made slice(0, -1) chop the last
+    // character, so a bare "node" yielded the directory "nod" — a truthy value
+    // that skipped the fallback and put a nonexistent dir at the FRONT of the
+    // scheduler PATH. Unreachable with a real process.execPath, which is
+    // absolute; a PATH built from a lie is still a PATH that can misresolve.
+    expect(schedulerPath("node").split(":")[0]).toBe("/usr/local/bin");
+    expect(schedulerPath("").split(":")[0]).toBe("/usr/local/bin");
+  });
 });
 
 describe("autoupdateStatus — a plist that cannot run must not report a clean 'enabled'", () => {

--- a/tests/auto-update.test.ts
+++ b/tests/auto-update.test.ts
@@ -12,7 +12,10 @@
  *     code path to them — asserted here by the deps surface)
  */
 import { describe, it, expect, vi } from "vitest";
-import { runPackageUpdate, buildAutoupdatePlist, AUTOUPDATE_LABEL } from "../src/autoUpdate.js";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPackageUpdate, buildAutoupdatePlist, resolvePrismBin, schedulerPath, AUTOUPDATE_LABEL } from "../src/autoUpdate.js";
 
 const base = () => ({
   currentVersion: "20.11.1",
@@ -112,12 +115,106 @@ describe("runPackageUpdate", () => {
 
 describe("buildAutoupdatePlist", () => {
   it("schedules `prism update --if-idle` — never connect, never host config", () => {
-    const plist = buildAutoupdatePlist("/usr/local/bin/prism");
+    const plist = buildAutoupdatePlist("/usr/local/bin/prism", "/usr/local/bin:/usr/bin:/bin");
     expect(plist).toContain(AUTOUPDATE_LABEL);
     expect(plist).toContain("<string>/usr/local/bin/prism</string>");
     expect(plist).toContain("<string>update</string>");
     expect(plist).toContain("<string>--if-idle</string>");
     expect(plist).not.toContain("connect");
     expect(plist).toContain("StartCalendarInterval");
+  });
+
+  // Measured 2026-08-14, simulating launchd's environment:
+  //   env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin prism update --if-idle
+  //   -> env: node: No such file or directory
+  // launchd gives an agent a minimal PATH that excludes /usr/local/bin, where
+  // node and npm live on a standard macOS install. Without an explicit PATH
+  // the scheduled updater could never start, and would have failed silently
+  // into a log file nobody reads. The plist must carry a PATH that contains
+  // the interpreter running this code.
+  it("carries a PATH that includes the running node's directory", () => {
+    const plist = buildAutoupdatePlist("/usr/local/bin/prism", "/opt/homebrew/bin:/usr/bin:/bin");
+    expect(plist).toContain("EnvironmentVariables");
+    const pathValue = plist.split("<key>PATH</key>")[1]?.split("</string>")[0] ?? "";
+    expect(pathValue).toContain("/opt/homebrew/bin");
+  });
+
+  it("escapes XML metacharacters so a path with & or < cannot corrupt the plist", () => {
+    const plist = buildAutoupdatePlist("/opt/a&b/prism", "/opt/a&b:/usr/bin");
+    expect(plist).not.toMatch(/[^&]&[^ag]/);   // no bare ampersands
+    expect(plist).toContain("&amp;");
+  });
+});
+
+describe("resolvePrismBin — which CLI the scheduler runs", () => {
+  it("prefers the npm global bin over whatever PATH resolves", () => {
+    const warnings: string[] = [];
+    const bin = resolvePrismBin((l) => warnings.push(l), {
+      npmPrefix: () => "/Users/dev/.npm-global\n",
+      whichPrism: () => "/Users/dev/bin/prism\n",
+      exists: () => true,
+    });
+    expect(bin).toBe("/Users/dev/.npm-global/bin/prism");
+    expect(warnings).toEqual([]);
+  });
+
+  it("does NOT call a PATH shim a source checkout (the 20.12.0 false positive)", () => {
+    // Live shape: /Users/dev/bin/prism is a two-line bash script that execs the
+    // real bin. readlink -f on a regular file returns the file itself, and the
+    // first version of this code read "not under node_modules" as "checkout".
+    const warnings: string[] = [];
+    const bin = resolvePrismBin((l) => warnings.push(l), {
+      npmPrefix: () => "",
+      whichPrism: () => "/Users/dev/bin/prism\n",
+      readlink: () => "/Users/dev/bin/prism\n",
+      exists: () => false,
+    });
+    expect(bin).toBe("/Users/dev/bin/prism");
+    expect(warnings).toEqual([]);
+  });
+
+  it("still warns for a genuine source checkout", () => {
+    const warnings: string[] = [];
+    resolvePrismBin((l) => warnings.push(l), {
+      npmPrefix: () => "",
+      whichPrism: () => "/Users/dev/prism/dist/cli.js\n",
+      readlink: () => "/Users/dev/prism/dist/cli.js\n",
+      exists: () => false,
+    });
+    expect(warnings.join(" ")).toMatch(/source checkout/);
+  });
+});
+
+describe("schedulerPath", () => {
+  it("leads with the running interpreter's directory and keeps launchd's defaults", () => {
+    const path = schedulerPath("/usr/local/bin/node");
+    expect(path.startsWith("/usr/local/bin:")).toBe(true);
+    expect(path).toContain("/usr/bin");
+    expect(path.split(":").filter((d) => d === "/usr/local/bin")).toHaveLength(1); // no duplicate
+  });
+
+  it("covers a Homebrew-ARM node too", () => {
+    expect(schedulerPath("/opt/homebrew/bin/node").startsWith("/opt/homebrew/bin:")).toBe(true);
+  });
+});
+
+describe("autoupdateStatus — a plist that cannot run must not report a clean 'enabled'", () => {
+  it("flags a 20.12.0-era PATH-less plist as needing repair", async () => {
+    const { autoupdateStatus } = await import("../src/autoUpdate.js");
+    const fakeHome = mkdtempSync(join(tmpdir(), "prism-agent-"));
+    mkdirSync(join(fakeHome, "Library", "LaunchAgents"), { recursive: true });
+    const prev = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      const { autoupdatePlistPath } = await import("../src/autoUpdate.js");
+      // Only meaningful on darwin; elsewhere status reports unsupported.
+      if (process.platform !== "darwin") return;
+      writeFileSync(autoupdatePlistPath(), "<plist><dict><key>Label</key></dict></plist>");
+      const status = autoupdateStatus();
+      expect(status.enabled).toBe(true);
+      expect(status.detail).toMatch(/CANNOT RUN|repair/);
+    } finally {
+      if (prev === undefined) delete process.env.HOME; else process.env.HOME = prev;
+    }
   });
 });

--- a/tests/tools/cli-connect.test.ts
+++ b/tests/tools/cli-connect.test.ts
@@ -2206,6 +2206,38 @@ describe("prism connect — economy subagent policy", () => {
     });
 
 
+    it("converges project entries even when the TOP-LEVEL entry is hand-rolled", () => {
+      // Untested branch found in round-4 review: an operator who hand-edited
+      // the top-level entry (no PRISM_INSTANCE, so Prism must not touch it)
+      // could still have Prism-created project entries pinned to a stale path.
+      // Leaving those behind because the top-level is off-limits would strand
+      // exactly the directories this change exists to reach.
+      const homeDir = makeHome();
+      const path = configPath(homeDir, "claude-code");
+      writeFileSync(path, JSON.stringify({
+        mcpServers: { "prism-mcp": { command: "hand-rolled", args: ["/my/server.js"] } },
+        projects: {
+          "/Users/dev": {
+            mcpServers: {
+              "prism-mcp": {
+                command: "/old/node",
+                args: ["/stale/dist/server.js"],
+                env: { PRISM_INSTANCE: "prism-mcp" },
+              },
+            },
+          },
+        },
+      }, null, 2));
+
+      const result = connectHosts({ ...base(homeDir), refresh: true });
+
+      const config = readConfig(path);
+      expect(config.mcpServers["prism-mcp"].command).toBe("hand-rolled");   // untouched
+      expect(config.projects["/Users/dev"].mcpServers["prism-mcp"].args).toEqual(["/pkg/dist/server.js"]);
+      expect(result.results[0].message ?? "").toMatch(/left untouched/);
+      expect(result.results[0].message ?? "").toMatch(/1 project-scoped entry/);
+    });
+
     it("the operator SEES the project-scoped detail — the message must reach stdout", () => {
       // Caught in pre-merge review: the writer reported "also refreshed 2
       // project-scoped entries" on the result while the CLI printed canned

--- a/tests/tools/cli-connect.test.ts
+++ b/tests/tools/cli-connect.test.ts
@@ -37,6 +37,7 @@ import {
   configureGeminiAgentPolicy,
   configureGeminiNativeStartup,
   connectHosts,
+  connectResultLine,
   migrateLegacyClaudeProjectMcp,
   migrateLegacyClaudeHooks,
   migrateLegacyClaudeInstructions,
@@ -2096,6 +2097,138 @@ describe("prism connect — economy subagent policy", () => {
     const block = src.split("CODEX_LOCAL_FIRST_POLICY = {")[1]?.slice(0, 600) ?? "";
     expect(block).toMatch(/max_threads:\s*1/);   // "at most one"
     expect(block).toMatch(/max_depth:\s*1/);     // "no nesting"
+  });
+
+
+  // ── Project-scoped Claude registrations (2026-08-14) ─────────────
+  // Found live: ~/.claude.json carried THREE prism-mcp registrations — the
+  // top-level one plus project-scoped entries under projects["<dir>"].
+  // `--refresh` converged only the top-level one, so sessions started in
+  // those directories kept launching a stale server path forever. Measured
+  // in an isolated HOME against a copy of the real config: top-level moved
+  // to the installed package, both project entries stayed on the old path.
+  describe("project-scoped Claude entries", () => {
+    function seedThreeRegistrations(homeDir: string, stalePath: string) {
+      const path = configPath(homeDir, "claude-code");
+      const managed = (extra: Record<string, unknown> = {}) => ({
+        command: "/old/node",
+        args: [stalePath],
+        env: { PRISM_INSTANCE: "prism-mcp", PRISM_STORAGE: "auto" },
+        ...extra,
+      });
+      writeFileSync(path, JSON.stringify({
+        mcpServers: { "prism-mcp": managed({ type: "stdio" }) },
+        projects: {
+          "/Users/dev": { mcpServers: { "prism-mcp": managed({ autoSearch: true }) } },
+          "/Users/dev/Scripts": { mcpServers: { "prism-mcp": managed() } },
+          "/Users/dev/other": { mcpServers: { custom: { command: "x" } } },
+        },
+      }, null, 2));
+      return path;
+    }
+
+    const base = (homeDir: string) => ({
+      hosts: ["claude-code"] as ConnectHostName[],
+      homeDir,
+      platform: "darwin" as const,
+      serverPath: "/pkg/dist/server.js",
+      nodePath: "/usr/bin/node",
+      env: {},
+    });
+
+    it("--refresh converges EVERY Prism-managed registration, not just the top-level one", () => {
+      const homeDir = makeHome();
+      const path = seedThreeRegistrations(homeDir, "/stale/dist/server.js");
+
+      const result = connectHosts({ ...base(homeDir), refresh: true });
+
+      expect(result.results[0].status).toBe("refreshed");
+      const config = readConfig(path);
+      expect(config.mcpServers["prism-mcp"].args).toEqual(["/pkg/dist/server.js"]);
+      expect(config.projects["/Users/dev"].mcpServers["prism-mcp"].args).toEqual(["/pkg/dist/server.js"]);
+      expect(config.projects["/Users/dev/Scripts"].mcpServers["prism-mcp"].args).toEqual(["/pkg/dist/server.js"]);
+      // Per-entry extras survive the refresh.
+      expect(config.projects["/Users/dev"].mcpServers["prism-mcp"].autoSearch).toBe(true);
+    });
+
+    it("refreshes project entries even when the top-level entry is already current", () => {
+      const homeDir = makeHome();
+      const path = configPath(homeDir, "claude-code");
+      connectHosts(base(homeDir));                       // writes a current top-level entry
+      const current = readConfig(path);
+      current.projects = {
+        "/Users/dev": {
+          mcpServers: {
+            "prism-mcp": {
+              command: "/old/node",
+              args: ["/stale/dist/server.js"],
+              env: { PRISM_INSTANCE: "prism-mcp" },
+            },
+          },
+        },
+      };
+      writeFileSync(path, JSON.stringify(current, null, 2));
+
+      const result = connectHosts({ ...base(homeDir), refresh: true });
+
+      expect(result.results[0].status).toBe("refreshed");
+      expect(readConfig(path).projects["/Users/dev"].mcpServers["prism-mcp"].args)
+        .toEqual(["/pkg/dist/server.js"]);
+    });
+
+    it("never touches a project entry that Prism did not create", () => {
+      const homeDir = makeHome();
+      const path = configPath(homeDir, "claude-code");
+      writeFileSync(path, JSON.stringify({
+        mcpServers: { "prism-mcp": { command: "/old/node", args: ["/stale/dist/server.js"], env: { PRISM_INSTANCE: "prism-mcp" } } },
+        projects: {
+          "/Users/dev": { mcpServers: { "prism-mcp": { command: "hand-rolled", args: ["/my/server.js"] } } },
+        },
+      }, null, 2));
+
+      connectHosts({ ...base(homeDir), refresh: true });
+
+      const entry = readConfig(path).projects["/Users/dev"].mcpServers["prism-mcp"];
+      expect(entry.command).toBe("hand-rolled");
+      expect(entry.args).toEqual(["/my/server.js"]);
+    });
+
+    it("dry run reports the project entries and writes nothing", () => {
+      const homeDir = makeHome();
+      const path = seedThreeRegistrations(homeDir, "/stale/dist/server.js");
+      const before = readFileSync(path, "utf8");
+
+      const preview = connectHosts({ ...base(homeDir), refresh: true, dryRun: true });
+
+      expect(preview.results[0].status).toBe("would-refresh");
+      expect(preview.results[0].message ?? "").toMatch(/2 project-scoped/);
+      expect(readFileSync(path, "utf8")).toBe(before);
+    });
+
+
+    it("the operator SEES the project-scoped detail — the message must reach stdout", () => {
+      // Caught in pre-merge review: the writer reported "also refreshed 2
+      // project-scoped entries" on the result while the CLI printed canned
+      // per-status text, so the convergence this change exists to perform was
+      // invisible to the person running the command.
+      const line = connectResultLine({
+        host: "claude-code", label: "Claude Code", path: "/home/.claude.json",
+        status: "refreshed", startupCompatible: true,
+        message: "also refreshed 2 project-scoped entries",
+      } as any);
+      expect(line).toContain("2 project-scoped entries");
+      expect(line).toContain("Claude Code");
+    });
+
+    it("without --refresh, project entries are left alone", () => {
+      const homeDir = makeHome();
+      const path = seedThreeRegistrations(homeDir, "/stale/dist/server.js");
+      const before = readFileSync(path, "utf8");
+
+      connectHosts(base(homeDir));
+
+      expect(readFileSync(path, "utf8")).toBe(before);
+    });
   });
 
   it("validates the Codex write against the declaration, not a literal", () => {


### PR DESCRIPTION
Two defects found by attacking yesterday's 20.12.0 release on a real machine.

**1. `connect --refresh` converged one registration out of three.**
Claude Code keeps additional directory-scoped entries under `projects["<dir>"].mcpServers`, and the scoped one wins for sessions started in that directory. Measured in an isolated HOME against a copy of a live config: the top-level entry moved to the installed package while two project entries stayed pinned to a stale server path — those directories would have launched an old build indefinitely.

Refresh now converges every Prism-managed entry **in the config files connect owns** — one atomic write per file, preserving per-entry extras and credentials, and only touching entries Prism created (`env.PRISM_INSTANCE`), never a hand-rolled one.

Scope limit, stated because a review caught the overclaim: this does **not** reach a registration owned by an installed plugin (`plugins/*/.mcp.json`, which registers `prism-mcp` via `npx -y prism-mcp-server`). That file belongs to the plugin, not to connect. A machine with both the plugin and a direct registration therefore keeps two servers under one name, and connect can converge only one of them — tracked separately as the duplicate-registration problem.

**2. The opt-in LaunchAgent could never run.**
launchd gives an agent `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, which excludes the directories holding node and npm on a standard macOS install:

```
env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin prism update --if-idle
→ env: node: No such file or directory
```

The plist now carries a PATH led by the running interpreter's directory and XML-escapes its values; `prism autoupdate status` reports a PATH-less 20.12.0-era plist as "enabled but CANNOT RUN … re-run to repair" instead of a confident "enabled". Bin resolution prefers the npm global bin and no longer mislabels a PATH shim as a source checkout.

**Found during pre-merge review:** the CLI printed canned per-status text and dropped the writer's message, so the project-scoped convergence was invisible to the operator. Formatting is now one tested function (`connectResultLine`).

**A third defect, found while reviewing the first two:** `prism update` compared the version of the CLI *making the call* instead of the globally installed package it updates. On this machine it reported "20.12.0 is current" while the installed package sat at 20.11.1 with 20.12.0 published — a command claiming success while its artifact stayed stale. It now resolves the installed version from the npm global prefix and applies the dev-build guard to that.

**Evidence**
- 30 tests added across the three fixes; 3,974 pass locally; CI green on macOS, Ubuntu and Windows.
- Mutation-tested: reverting each connect fix individually kills a test (3/3).
- Live, on a real config shape: three stale registrations → all three converged, `autoSearch` and API keys preserved, second run idempotent.
- Live red→green: `env: node: No such file or directory` → `deferred: 3 Prism MCP process(es) running`.
- Live, stubbed installer: `WOULD INSTALL -> 20.12.0 / action: updated` where the same call previously said `current`.
- Verified rather than assumed: `writeTextAtomically` writes a temp file with `O_EXCL`, compares the original text before an atomic rename, and aborts on a concurrent host edit.

**Scope limits stated deliberately:** a plugin-owned `.mcp.json` is not reachable by connect; `--if-idle` may never find an idle moment on a machine that keeps sessions open; `autoupdate status` infers "enabled" from the plist existing rather than from launchd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


