### PR TITLE
feat(infer): prism_infer accepts screenshots

### DIFF
--- a/src/tools/__tests__/layer1Integration.test.ts
+++ b/src/tools/__tests__/layer1Integration.test.ts
@@ -462,8 +462,9 @@ describe("Layer 1 handler integration", () => {
         );
 
         expect(callCount).toBe(2);
-        expect(callLocal).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything(), expect.anything(), expect.anything(), true);
-        expect(callLocal).toHaveBeenNthCalledWith(2, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything(), expect.anything(), expect.anything(), false);
+        // 9th arg = images (undefined for text calls) — added 2026-08-14 when prism_infer gained screenshot support.
+        expect(callLocal).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything(), expect.anything(), expect.anything(), true, undefined);
+        expect(callLocal).toHaveBeenNthCalledWith(2, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything(), expect.anything(), expect.anything(), false, undefined);
         expect(result.output).toBe("answer without thinking");
         expect(result.used_cloud).toBe(false);
     });

--- a/src/tools/prismInferHandler.ts
+++ b/src/tools/prismInferHandler.ts
@@ -109,6 +109,15 @@ export const PRISM_INFER_TOOL: Tool = {
     inputSchema: {
         type: "object",
         properties: {
+            images: {
+                type: "array",
+                items: { type: "string" },
+                maxItems: 8,
+                description:
+                    "Screenshots or frames to analyse. Each entry is an absolute file path " +
+                    "or raw base64. Requires a vision-capable tier; tiers without vision are " +
+                    "skipped rather than shown the prompt without the image.",
+            },
             prompt: {
                 type: "string",
                 description: "The user prompt. Required.",
@@ -265,6 +274,11 @@ export const PRISM_INFER_TOOL: Tool = {
 export interface PrismInferArgs {
     prompt: string;
     system?: string;
+    /** Screenshots/frames for a vision-capable tier. Each entry is either raw
+     *  base64 or an absolute filesystem path (read and encoded here). Capped at
+     *  8: images are the dominant context cost and an unbounded list silently
+     *  blows the tier context budget. */
+    images?: string[];
     max_tokens?: number;
     temperature?: number;
     model_ceiling?: "27b" | "9b" | "4b" | "2b";
@@ -314,6 +328,10 @@ export function isPrismInferArgs(args: unknown): args is PrismInferArgs {
     const a = args as Record<string, unknown>;
     if (typeof a.prompt !== "string" || !a.prompt.trim()) return false;
     if (a.system !== undefined && typeof a.system !== "string") return false;
+    if (a.images !== undefined) {
+        if (!Array.isArray(a.images) || a.images.length > MAX_INFER_IMAGES) return false;
+        if (a.images.some((i: unknown) => typeof i !== "string" || !i.trim())) return false;
+    }
     if (a.max_tokens !== undefined && typeof a.max_tokens !== "number") return false;
     if (a.temperature !== undefined && typeof a.temperature !== "number") return false;
     if (a.cloud_fallback !== undefined && typeof a.cloud_fallback !== "boolean") return false;
@@ -501,6 +519,85 @@ interface OllamaChatResp {
     eval_count?: number;
 }
 
+export const MAX_INFER_IMAGES = 8;
+/** Bytes per supplied image. Beyond this the base64 blows request memory and
+ *  the tier timeout before the model ever sees it. */
+export const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+/** Prompt-token cost of ONE image. Measured live 2026-08-14: a 1206x2622
+ *  screenshot produced tokens=3156in against a ~30-token prompt. The 9b/27b
+ *  tiers advertise ctxTokens 4_096, so this MUST be charged to the context
+ *  gate — counting only the text prompt let two images silently overflow. */
+export const IMAGE_TOKEN_ESTIMATE = 3_000;
+
+export function estimateImageTokens(count: number): number {
+    return Math.max(0, count) * IMAGE_TOKEN_ESTIMATE;
+}
+
+/** Resolve caller-supplied images to raw base64.
+ *  A filesystem path is read and encoded; anything else is assumed to be
+ *  base64 already. A path that cannot be read THROWS rather than being passed
+ *  through — sending a filename as if it were image bytes produces a
+ *  confidently wrong answer about an image the model never saw. */
+export async function prepareImages(images: string[]): Promise<string[]> {
+    const fs = await import("node:fs/promises");
+    const out: string[] = [];
+    for (const entry of images) {
+        // Windows drive paths (C:\\...) and UNC (\\\\server\\share) are paths too;
+        // treating them as base64 sends a filename as image bytes.
+        const looksLikePath = entry.startsWith("/") || entry.startsWith("./") || entry.startsWith("~")
+            || /^[A-Za-z]:[\\/]/.test(entry) || entry.startsWith("\\\\");
+        if (looksLikePath) {
+            try {
+                const resolved = entry.replace(/^~/, process.env.HOME ?? "~");
+                const stat = await fs.stat(resolved);
+                if (stat.size > MAX_IMAGE_BYTES) {
+                    throw new Error(`image too large: ${(stat.size / 1024 / 1024).toFixed(1)}MB > ${MAX_IMAGE_BYTES / 1024 / 1024}MB`);
+                }
+                const buf = await fs.readFile(resolved);
+                out.push(buf.toString("base64"));
+            } catch (err) {
+                throw new Error(`prism_infer: image path not readable: ${entry} (${err instanceof Error ? err.message : String(err)})`);
+            }
+        } else {
+            out.push(entry);
+        }
+    }
+    return out;
+}
+
+/** Ask Ollama which of these models actually declare vision.
+ *  Fail-safe: a model we cannot probe is treated as NOT vision-capable, so an
+ *  image request degrades to "no viable tier" instead of being silently sent
+ *  to a text-only model that will hallucinate a description. */
+export async function tiersSupportingVision(
+    url: string,
+    models: string[],
+    probe: (url: string, model: string) => Promise<boolean>,
+): Promise<string[]> {
+    const keep: string[] = [];
+    for (const m of models) {
+        try {
+            if (await probe(url, m)) keep.push(m);
+        } catch {
+            // unprobeable → excluded
+        }
+    }
+    return keep;
+}
+
+/** Default vision probe: /api/show reports capabilities for the local model. */
+export async function probeVision(url: string, model: string): Promise<boolean> {
+    const res = await fetch(`${url}/api/show`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model }),
+        signal: AbortSignal.timeout(5_000),
+    });
+    if (!res.ok) throw new Error(`show_http_${res.status}`);
+    const data = (await res.json()) as { capabilities?: string[] };
+    return Array.isArray(data.capabilities) && data.capabilities.includes("vision");
+}
+
 async function callOllamaGenerate(
     url: string,
     model: string,
@@ -510,11 +607,12 @@ async function callOllamaGenerate(
     temperature: number,
     timeoutMs: number,
     think?: boolean,
+    images?: string[],
 ): Promise<{ ok: true; text: string; doneReason?: string; promptTokens?: number; completionTokens?: number } | { ok: false; reason: string }> {
     try {
-        const messages: Array<{ role: string; content: string }> = [];
+        const messages: Array<{ role: string; content: string; images?: string[] }> = [];
         if (system) messages.push({ role: "system", content: system });
-        messages.push({ role: "user", content: prompt });
+        messages.push({ role: "user", content: prompt, ...(images?.length ? { images } : {}) });
         const body = {
             model,
             messages,
@@ -807,7 +905,7 @@ export interface InferDeps {
     freemem: () => number;
     listTags: () => Promise<Set<string> | null>;
     listLoaded: () => Promise<Set<string>>;
-    callLocal: (url: string, model: string, prompt: string, system: string | undefined, maxTokens: number, temperature: number, timeoutMs: number, think?: boolean) => ReturnType<typeof callOllamaGenerate>;
+    callLocal: (url: string, model: string, prompt: string, system: string | undefined, maxTokens: number, temperature: number, timeoutMs: number, think?: boolean, images?: string[]) => ReturnType<typeof callOllamaGenerate>;
     callCloud: typeof callSynaluxInference;
     ollamaUrl: string;
     /** Injectable verifier for testing. When omitted, verification is skipped (portal-side). */
@@ -820,6 +918,8 @@ export interface InferDeps {
     }) => Promise<RouteGuardOutcome>;
     /** Injectable entitlements for testing. When omitted, fetched live. */
     entitlements?: PrismEntitlements;
+    /** Injectable vision probe for testing. Defaults to probeVision (/api/show). */
+    probeVision?: (url: string, model: string) => Promise<boolean>;
     /** Injectable Layer 1 classifier for testing. Defaults to callLayer1 from layer1.ts. */
     callLayer1?: (userPrompt: string, ollamaUrl: string, model: string) => Promise<Layer1Verdict>;
 }
@@ -1169,6 +1269,20 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
             }
         }
 
+        // Images: resolve once, then restrict the ladder to tiers that actually
+        // declare vision. A text-only model handed a prompt about "this
+        // screenshot" answers confidently about an image it never received —
+        // so an unprobeable or text-only tier is skipped, not silently used.
+        let resolvedImages: string[] | undefined;
+        let visionOk: Set<string> | undefined;
+        if (args.images?.length) {
+            resolvedImages = await prepareImages(args.images);
+            const candidates = MODEL_TIERS.slice(ceilStart)
+                .map(t => resolveOllamaName(t.tag, installed))
+                .filter((n): n is string => !!n);
+            visionOk = new Set(await tiersSupportingVision(deps.ollamaUrl, candidates, deps.probeVision ?? probeVision));
+        }
+
         let anyViable = false;
 
         for (let i = ceilStart; i < MODEL_TIERS.length; i++) {
@@ -1199,18 +1313,22 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
             // unroutable to the 4096-ctx tiers even for tiny prompts.
             // ctxTokens mirrors the live Modelfile values (see MODEL_TIERS).
             const CTX_TEMPLATE_MARGIN = 64;
-            const promptTokensEst = estimateTokens(args.prompt)
+            const promptTokensEst = estimateImageTokens(resolvedImages?.length ?? 0) + estimateTokens(args.prompt)
                 + (args.system ? estimateTokens(args.system) : 0)
                 + CTX_TEMPLATE_MARGIN;
             if (promptTokensEst > tier.ctxTokens) {
                 attempts.push({ tier: tier.tag, reason: "ctx_insufficient" });
                 continue;
             }
+            if (visionOk && !visionOk.has(ollamaName)) {
+                attempts.push({ tier: tier.tag, reason: "no_vision" });
+                continue;
+            }
             anyViable = true;
             const timeout = args.timeout_ms ?? DEFAULT_TIMEOUTS[tier.tag] ?? 60_000;
             const enableThink = resolveThinkingMode(args, mode);
             let result = await deps.callLocal(
-                deps.ollamaUrl, ollamaName, args.prompt, args.system, maxTokens, temperature, timeout, enableThink,
+                deps.ollamaUrl, ollamaName, args.prompt, args.system, maxTokens, temperature, timeout, enableThink, resolvedImages,
             );
             // Think-only retry: model burned all tokens on <think>, empty content.
             // Retry same model with think=false rather than falling to a smaller tier.
@@ -1219,7 +1337,7 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
                 debugLog(`[prism_infer] ${tier.tag} returned think-only — retrying with think=false`);
                 recordThinkOnlyRetry();
                 result = await deps.callLocal(
-                    deps.ollamaUrl, ollamaName, args.prompt, args.system, maxTokens, temperature, timeout, false,
+                    deps.ollamaUrl, ollamaName, args.prompt, args.system, maxTokens, temperature, timeout, false, resolvedImages,
                 );
             }
             if (result.ok) {

--- a/src/tools/prismInferHandler.ts
+++ b/src/tools/prismInferHandler.ts
@@ -549,12 +549,20 @@ export async function prepareImages(images: string[]): Promise<string[]> {
         if (looksLikePath) {
             try {
                 const resolved = entry.replace(/^~/, process.env.HOME ?? "~");
-                const stat = await fs.stat(resolved);
-                if (stat.size > MAX_IMAGE_BYTES) {
-                    throw new Error(`image too large: ${(stat.size / 1024 / 1024).toFixed(1)}MB > ${MAX_IMAGE_BYTES / 1024 / 1024}MB`);
+                // Single handle: stat-then-read lets the path be swapped between
+                // check and use (CodeQL js/file-system-race). Size is checked on
+                // the SAME handle that is read.
+                const handle = await fs.open(resolved, "r");
+                try {
+                    const stat = await handle.stat();
+                    if (stat.size > MAX_IMAGE_BYTES) {
+                        throw new Error(`image too large: ${(stat.size / 1024 / 1024).toFixed(1)}MB > ${MAX_IMAGE_BYTES / 1024 / 1024}MB`);
+                    }
+                    const buf = await handle.readFile();
+                    out.push(buf.toString("base64"));
+                } finally {
+                    await handle.close();
                 }
-                const buf = await fs.readFile(resolved);
-                out.push(buf.toString("base64"));
             } catch (err) {
                 throw new Error(`prism_infer: image path not readable: ${entry} (${err instanceof Error ? err.message : String(err)})`);
             }
@@ -1484,6 +1492,18 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
     // ── Local exhausted. Optional synalux fallback. ──
     if (allowCloud) {
         const cloudTimeout = args.timeout_ms ?? 90_000;
+        // Images never leave the device: callCloud has no image channel, so a
+        // cloud fallback would send "describe this screenshot" WITHOUT the
+        // screenshot and get a confident answer about an image the model never
+        // saw — the same failure the vision tier gate prevents locally. Refuse
+        // instead, and keep screenshot bytes on-device by construction.
+        if (args.images?.length) {
+            attempts.push({ tier: "synalux", reason: "cloud_fallback_refused_images_stay_local" });
+            throw new Error(
+                `prism_infer: no local vision tier could serve this image request, and cloud fallback is refused ` +
+                `for image inputs (screenshots stay on this device). attempts=${JSON.stringify(attempts)}`
+            );
+        }
         const cloud = await deps.callCloud(args.prompt, maxTokens, cloudTimeout);
         if (cloud.ok && cloud.output) {
             return await applyVerification(cloud.output, gatedArgs, deps, {

--- a/tests/tools/infer-images.test.ts
+++ b/tests/tools/infer-images.test.ts
@@ -1,0 +1,181 @@
+/**
+ * prism_infer image support.
+ *
+ * Measured 2026-08-14: the whole local set was repackaged to restore vision
+ * (9b/4b/2b now report `vision`), yet prism_infer had NO image parameter — so
+ * the capability was unreachable through the routing path every caller uses.
+ * A screenshot could only be judged by bypassing infer and calling ollama
+ * directly, which skips Layer 1, entitlements, RAM gating and telemetry.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { isPrismInferArgs, prepareImages, tiersSupportingVision } from "../../src/tools/prismInferHandler.js";
+
+const B64 = "iVBORw0KGgoAAAANSUhEUg==";
+
+describe("images arg validation", () => {
+  it("accepts a base64 image list", () => {
+    expect(isPrismInferArgs({ prompt: "x", images: [B64] })).toBe(true);
+  });
+  it("rejects non-array and non-string entries", () => {
+    expect(isPrismInferArgs({ prompt: "x", images: B64 })).toBe(false);
+    expect(isPrismInferArgs({ prompt: "x", images: [123] })).toBe(false);
+  });
+  it("rejects an unbounded image count", () => {
+    expect(isPrismInferArgs({ prompt: "x", images: Array(9).fill(B64) })).toBe(false);
+  });
+});
+
+describe("prepareImages", () => {
+  it("passes base64 through untouched", async () => {
+    expect(await prepareImages([B64])).toEqual([B64]);
+  });
+  it("reads a filesystem path and base64-encodes it", async () => {
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const p = join(mkdtempSync(join(tmpdir(), "infer-img-")), "a.png");
+    writeFileSync(p, Buffer.from([1, 2, 3, 4]));
+    expect(await prepareImages([p])).toEqual([Buffer.from([1, 2, 3, 4]).toString("base64")]);
+  });
+  it("throws on a path that does not exist rather than sending a filename as base64", async () => {
+    await expect(prepareImages(["/no/such/file.png"])).rejects.toThrow(/not readable|ENOENT/i);
+  });
+});
+
+describe("vision tier gating", () => {
+  it("keeps only vision-capable tiers when images are present", async () => {
+    const probe = vi.fn(async (_u: string, m: string) => m.includes("27b") ? false : true);
+    const tiers = await tiersSupportingVision("http://x", ["prism-coder:27b", "prism-coder:9b"], probe);
+    expect(tiers).toEqual(["prism-coder:9b"]);
+  });
+  it("treats an unprobeable model as NOT vision-capable (fail safe)", async () => {
+    const probe = vi.fn(async () => { throw new Error("ollama down"); });
+    expect(await tiersSupportingVision("http://x", ["prism-coder:9b"], probe)).toEqual([]);
+  });
+});
+
+describe("round-1 review findings", () => {
+  it("charges image tokens against the tier context budget", async () => {
+    const { estimateImageTokens, IMAGE_TOKEN_ESTIMATE } = await import("../../src/tools/prismInferHandler.js");
+    // Measured live 2026-08-14: one 1206x2622 screenshot = ~3,100 prompt tokens.
+    // The 9b/27b tiers advertise ctxTokens 4_096, so TWO images cannot fit and
+    // the ctx gate must know that — it previously counted only the text prompt.
+    expect(IMAGE_TOKEN_ESTIMATE).toBeGreaterThanOrEqual(2_500);
+    expect(estimateImageTokens(2)).toBeGreaterThan(4_096);
+    expect(estimateImageTokens(0)).toBe(0);
+  });
+
+  it("refuses an oversized image instead of base64-ing it into memory", async () => {
+    const { prepareImages, MAX_IMAGE_BYTES } = await import("../../src/tools/prismInferHandler.js");
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const p = join(mkdtempSync(join(tmpdir(), "infer-big-")), "big.png");
+    writeFileSync(p, Buffer.alloc(MAX_IMAGE_BYTES + 1024));
+    await expect(prepareImages([p])).rejects.toThrow(/too large/i);
+  });
+});
+
+describe("round-2: the 27b must stay reachable for text/coding", () => {
+  it("vision filtering does NOT apply when no images are supplied", async () => {
+    const { isPrismInferArgs } = await import("../../src/tools/prismInferHandler.js");
+    // Guard the contract: a text call carries no images, so the ladder is
+    // untouched and the 27b coding tier remains selectable.
+    expect(isPrismInferArgs({ prompt: "write a function", model_ceiling: "27b" })).toBe(true);
+    const src = await import("node:fs").then(fs =>
+      fs.readFileSync("src/tools/prismInferHandler.ts", "utf8"));
+    expect(src).toMatch(/if \(args\.images\?\.length\)/);      // gating is conditional
+    expect(src).toMatch(/visionOk && !visionOk\.has\(ollamaName\)/); // skip only when set
+  });
+});
+
+// ── Chain-level tests (mocked deps, no live models) ────────────────────
+import { runInfer, type InferDeps } from "../../src/tools/prismInferHandler.js";
+import { _setCacheForTest, _resetEntitlementsForTest, type PrismEntitlements } from "../../src/utils/entitlements.js";
+
+const ENTERPRISE_ENTITLEMENTS: PrismEntitlements = {
+  plan: "enterprise", model_ceiling: "27b", daily_infer_limit: 100000,
+  max_tokens: 4096, max_seats: 25,
+  features: { cloud_fallback: true, grounding_verifier: true, route_guard: true,
+              knowledge_search_unlimited: true, session_memory_unlimited: true,
+              analytics_dashboard: true },
+  upgrade_url: "https://synalux.ai/pricing",
+};
+import { beforeEach, afterAll } from "vitest";
+const GB = 1024 ** 3;
+const ALL = new Set(["prism-coder:27b", "prism-coder:9b", "prism-coder:4b", "prism-coder:2b"]);
+function deps(o: Partial<InferDeps> = {}): InferDeps {
+  return {
+    freemem: () => 30 * GB,
+    listTags: async () => ALL,
+    listLoaded: async () => new Set<string>(),
+    callLocal: async () => ({ ok: true as const, text: "ok", doneReason: "stop" }),
+    callCloud: async () => ({ ok: false as const, reason: "cloud_disabled" }),
+    ollamaUrl: "http://x",
+    callLayer1: async () => "OBVIOUS_NOT_RESERVED",
+    entitlements: ENTERPRISE_ENTITLEMENTS,
+    ...o,
+  } as InferDeps;
+}
+
+// Harness note: entitlements are read from a module cache, not from deps —
+// without _setCacheForTest the ladder clamps to the free tier and never
+// reaches 9b/27b. Complexity buckets: <=3 -> 4b, <=6 -> 9b, >6 -> 27b.
+beforeEach(() => { _setCacheForTest(ENTERPRISE_ENTITLEMENTS, 60_000); });
+afterAll(() => { _resetEntitlementsForTest(); });
+
+describe("infer chain with screenshots", () => {
+  it("routes an image request to a vision tier and forwards the images", async () => {
+    const seen: Array<string[] | undefined> = [];
+    const r = await runInfer(
+      { prompt: "what is occluded?", images: [B64], mode: "chat", task_complexity: 5 },
+      deps({
+        probeVision: async (_u, m) => m.includes("9b"),
+        callLocal: async (_u, _m, _p, _s, _mt, _t, _to, _th, images) => {
+          seen.push(images);
+          return { ok: true as const, text: "YES — Sources & Citations", doneReason: "stop" };
+        },
+      }));
+    expect(r.model_picked).toContain("9b");
+    expect(seen[0]).toEqual([B64]);          // images actually reached the model
+  });
+
+  it("SKIPS a text-only tier rather than showing it a prompt about an image it never got", async () => {
+    const tried: string[] = [];
+    const r = await runInfer(
+      { prompt: "what is occluded?", images: [B64], mode: "chat", task_complexity: 9 },
+      deps({
+        probeVision: async (_u, m) => !m.includes("27b"),   // 27b text-only, like production
+        callLocal: async (_u, m) => { tried.push(m); return { ok: true as const, text: "ok", doneReason: "stop" }; },
+      }));
+    expect(r.output.length).toBeGreaterThan(0);
+    expect(tried.some(m => m.includes("27b"))).toBe(false); // never handed the image prompt
+    expect(tried.some(m => m.includes("9b"))).toBe(true);   // 9b remains the workhorse
+  });
+
+  it("stays LOCAL-FIRST when the ceiling tier lacks RAM — degrades to 9b, never the cloud", async () => {
+    const tried: string[] = [];
+    let cloudCalls = 0;
+    const r = await runInfer(
+      { prompt: "write a clamp fn", mode: "code", task_complexity: 9 },
+      deps({
+        freemem: () => 10 * GB,                       // below the 27b's 20GB floor
+        callLocal: async (_u, m) => { tried.push(m); return { ok: true as const, text: "const clamp=…", doneReason: "stop" }; },
+        callCloud: async () => { cloudCalls++; return { ok: false as const, reason: "should_not_be_called" }; },
+      }));
+    expect(r.used_cloud).toBe(false);
+    expect(tried.some(m => m.includes("27b"))).toBe(false);
+    expect(tried.some(m => m.includes("9b"))).toBe(true);
+    expect(cloudCalls).toBe(0);
+  });
+});
+
+describe("round-2 review findings", () => {
+  it("treats a Windows path as a path, not as base64", async () => {
+    // The CLI ships cross-platform. `C:\Users\...\shot.png` fails the
+    // startsWith("/") test, so it was passed through as if it WERE image
+    // bytes — the model then answers confidently about an image it never got,
+    // which is the exact failure mode the throw-on-unreadable rule exists for.
+    await expect(prepareImages(["C:\\Users\\dev\\shot.png"])).rejects.toThrow(/not readable|ENOENT/i);
+  });
+});

--- a/tests/tools/infer-images.test.ts
+++ b/tests/tools/infer-images.test.ts
@@ -179,3 +179,27 @@ describe("round-2 review findings", () => {
     await expect(prepareImages(["C:\\Users\\dev\\shot.png"])).rejects.toThrow(/not readable|ENOENT/i);
   });
 });
+
+describe("round-3 review: security + privacy", () => {
+  it("reads the image through a single handle (no stat/read TOCTOU)", async () => {
+    // CodeQL js/file-system-race (high): stat() then readFile() lets the path
+    // be swapped between check and use. The size check must apply to the SAME
+    // open handle that is read.
+    const src = await import("node:fs").then(fs =>
+      fs.readFileSync("src/tools/prismInferHandler.ts", "utf8"));
+    expect(src).toMatch(/fs\.open\(/);
+    expect(src).not.toMatch(/await fs\.stat\(resolved\)/);
+  });
+
+  it("REFUSES cloud fallback when images are present — never sends a screenshot prompt without the screenshot", async () => {
+    let cloudCalls = 0;
+    await expect(runInfer(
+      { prompt: "what is occluded?", images: [B64], mode: "chat", task_complexity: 5, cloud_fallback: true },
+      deps({
+        probeVision: async () => true,
+        callLocal: async () => ({ ok: false as const, reason: "all_local_failed" }),
+        callCloud: async () => { cloudCalls++; return { ok: true as const, text: "cloud answer", backend: "gemini" } as any; },
+      }))).rejects.toThrow();
+    expect(cloudCalls).toBe(0);   // image content stays on-device AND no blind answer
+  });
+});


### PR DESCRIPTION
The local set was repackaged today so 9b/4b/2b report `vision`, but `prism_infer` had **no image parameter** — the capability was unreachable through the routing path every caller uses. Judging a screenshot meant bypassing infer entirely, which skips Layer 1, entitlements, RAM gating and telemetry.

**What this adds**
- `images[]` (≤8): absolute path or base64. Paths are read and encoded; an unreadable path **throws** rather than being forwarded as image bytes (otherwise the model answers confidently about an image it never received). Windows drive/UNC paths count as paths.
- **Vision-aware tier gating** — with images present, the ladder is filtered by an `/api/show` probe, and an unprobeable tier is treated as **not** vision-capable (fail safe). Text calls are untouched, so the 27b coding tier keeps its place.
- **Image tokens charged to the context gate** — measured live: one 1206×2622 screenshot = **3,156 prompt tokens** vs the 9b's 4,096 ctx, so two images must skip that tier. Previously only the text prompt counted.
- 12 MB per-image cap before base64.

**Evidence**
- Live: `prism_infer` with a screenshot path routed to the 9b → *"YES — it covers part of the text 'Sources & Citations'"*.
- Local-first holds: a RAM-starved 27b degrades to the 9b, `used_cloud=false`.
- 15 new tests; 3,957 pass. Mutation-verified: dropping the vision skip or the image forwarding each kills a test.

**Known open risk (not addressed here):** Layer 1, the reserved-content classifier, sees the **text prompt only** — image content is never classified. A screenshot of clinical material bypasses that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)