### PR TITLE
fix(safety): Layer 1 must see the image, not just the prompt

### DIFF
--- a/src/tools/prismInferHandler.ts
+++ b/src/tools/prismInferHandler.ts
@@ -929,7 +929,7 @@ export interface InferDeps {
     /** Injectable vision probe for testing. Defaults to probeVision (/api/show). */
     probeVision?: (url: string, model: string) => Promise<boolean>;
     /** Injectable Layer 1 classifier for testing. Defaults to callLayer1 from layer1.ts. */
-    callLayer1?: (userPrompt: string, ollamaUrl: string, model: string) => Promise<Layer1Verdict>;
+    callLayer1?: (userPrompt: string, ollamaUrl: string, model: string, fetchImpl?: typeof fetch, images?: string[]) => Promise<Layer1Verdict>;
 }
 
 /**
@@ -1112,10 +1112,16 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
     // Recursion guard: skip when this call IS the Layer 1 classification
     // (mode="route" + max_tokens<=16 is the Layer 1 call signature).
     const layer1RecursionGuard = mode === "route" && maxTokens <= 16;
+    // Resolved BEFORE Layer 1: the classifier must see the same images the
+    // model will. Classifying only the text prompt let a screenshot of
+    // clinical material through a gate that never looked at it.
+    const resolvedImages: string[] | undefined =
+        args.images?.length ? await prepareImages(args.images) : undefined;
     if (installed && !layer1RecursionGuard) {
         const l1fn = deps.callLayer1 ?? defaultCallLayer1;
         const l1Model = resolveOllamaName("prism-coder:4b", installed);
-        const l1 = await l1fn(args.prompt, deps.ollamaUrl, l1Model);
+        // 4th arg is fetchImpl (default), 5th is the images the classifier must see.
+        const l1 = await l1fn(args.prompt, deps.ollamaUrl, l1Model, undefined, resolvedImages);
         if (l1 === "OBVIOUS_RESERVED" || l1 === "UNCERTAIN") {
             debugLog(`[prism_infer] Layer 1 verdict=${l1} — reserved content detected`);
             attempts.push({ tier: "layer1", reason: `layer1_${l1.toLowerCase()}` });
@@ -1277,14 +1283,12 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
             }
         }
 
-        // Images: resolve once, then restrict the ladder to tiers that actually
-        // declare vision. A text-only model handed a prompt about "this
-        // screenshot" answers confidently about an image it never received —
-        // so an unprobeable or text-only tier is skipped, not silently used.
-        let resolvedImages: string[] | undefined;
+        // Restrict the ladder to tiers that actually declare vision. A text-only
+        // model handed a prompt about "this screenshot" answers confidently
+        // about an image it never received — so an unprobeable or text-only
+        // tier is skipped, not silently used.
         let visionOk: Set<string> | undefined;
         if (args.images?.length) {
-            resolvedImages = await prepareImages(args.images);
             const candidates = MODEL_TIERS.slice(ceilStart)
                 .map(t => resolveOllamaName(t.tag, installed))
                 .filter((n): n is string => !!n);

--- a/src/utils/layer1.ts
+++ b/src/utils/layer1.ts
@@ -196,6 +196,10 @@ export function classifyDeterministicLayer1(userPrompt: string): Layer1Verdict |
 }
 
 const LAYER1_TIMEOUT_MS = 1_500;
+/** Image classify budget. A vision pass carries ~3,000 image tokens; the
+ *  1.5s text budget would time out every call and make the gate useless —
+ *  a gate that always errors is a gate that never gates. */
+export const LAYER1_IMAGE_TIMEOUT_MS = 10_000;
 const LAYER1_RETRY_TIMEOUT_MS = 5_000;
 
 // Deterministic reserved-vocabulary backstop for the ERROR path.
@@ -265,6 +269,10 @@ export async function callLayer1(
     ollamaUrl: string,
     model: string,
     fetchImpl: typeof fetch = fetch,
+    /** Images accompanying the request. The classifier MUST see them: a
+     *  screenshot of clinical material would otherwise pass a gate that only
+     *  ever read the text prompt. */
+    images?: string[],
 ): Promise<Layer1Verdict> {
     if (!userPrompt || !userPrompt.trim()) return "ERROR";
 
@@ -290,7 +298,11 @@ export async function callLayer1(
                 body: JSON.stringify({
                     model,
                     messages: [
-                        { role: "user", content: LAYER1_PROMPT.replace("{prompt}", classifierInput) },
+                        {
+                            role: "user",
+                            content: LAYER1_PROMPT.replace("{prompt}", classifierInput),
+                            ...(images?.length ? { images } : {}),
+                        },
                     ],
                     stream: false,
                     think: false,
@@ -316,8 +328,17 @@ export async function callLayer1(
         return parseLayer1(text);
     };
 
-    const first = await classify(LAYER1_TIMEOUT_MS);
-    const verdict = first !== "ERROR" ? first : await classify(LAYER1_RETRY_TIMEOUT_MS);
+    // Image requests get the vision budget on both attempts, and an ERROR is
+    // mapped to UNCERTAIN: with text, ERROR falls through to a keyword backstop
+    // that can still read the prompt; with an image there is NOTHING to fall
+    // back on — the gate saw nothing — so unclassifiable image content must be
+    // treated as reserved-handling, never silently allowed.
+    const hasImages = !!images?.length;
+    const firstBudget = hasImages ? LAYER1_IMAGE_TIMEOUT_MS : LAYER1_TIMEOUT_MS;
+    const retryBudget = hasImages ? LAYER1_IMAGE_TIMEOUT_MS : LAYER1_RETRY_TIMEOUT_MS;
+    const first = await classify(firstBudget);
+    const settled = first !== "ERROR" ? first : await classify(retryBudget);
+    const verdict: Layer1Verdict = (hasImages && settled === "ERROR") ? "UNCERTAIN" : settled;
 
     if (!oversize) return verdict;
 

--- a/tests/tools/layer1-images.test.ts
+++ b/tests/tools/layer1-images.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Layer 1 must see the image, not just the prompt.
+ *
+ * Gap found in the 2026-08-14 pre-merge review: prism_infer gained image
+ * support, but the reserved-content classifier still received the TEXT PROMPT
+ * ONLY. A screenshot of clinical material — a SOAP note, a medication label,
+ * an AAC session capture — passed the safety gate untouched, because the gate
+ * never looked at it. On a product with life-critical AAC evals, "the gate
+ * cannot see the input" is the whole failure.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { callLayer1, LAYER1_IMAGE_TIMEOUT_MS } from "../../src/utils/layer1.js";
+
+const B64 = "iVBORw0KGgoAAAANSUhEUg==";
+
+function fetchReturning(content: string, opts: { capture?: (body: any) => void } = {}) {
+  return vi.fn(async (_url: any, init: any) => {
+    opts.capture?.(JSON.parse(init.body));
+    return { ok: true, json: async () => ({ message: { content } }) } as any;
+  });
+}
+
+describe("callLayer1 with images", () => {
+  it("attaches the images to the classify request", async () => {
+    let body: any;
+    const f = fetchReturning("OBVIOUS_NOT_RESERVED", { capture: b => { body = b; } });
+    await callLayer1("what is on this screen?", "http://x", "m", f as any, [B64]);
+    const userMsg = body.messages.find((m: any) => m.role === "user");
+    expect(userMsg.images).toEqual([B64]);
+  });
+
+  it("returns RESERVED when the classifier flags the image content", async () => {
+    const f = fetchReturning("OBVIOUS_RESERVED");
+    expect(await callLayer1("describe this", "http://x", "m", f as any, [B64]))
+      .toBe("OBVIOUS_RESERVED");
+  });
+
+  it("an unclassifiable IMAGE is UNCERTAIN, never silently allowed", async () => {
+    // Text-only ERROR falls through to a keyword backstop that can read the
+    // prompt. With an image there is nothing to fall back on — the gate saw
+    // nothing — so the conservative verdict is UNCERTAIN (reserved handling).
+    const f = vi.fn(async () => { throw new Error("timeout"); });
+    expect(await callLayer1("describe this", "http://x", "m", f as any, [B64]))
+      .toBe("UNCERTAIN");
+  });
+
+  it("gives image classification a longer budget than the 1.5s text path", () => {
+    // A vision classify carries ~3,000 image tokens; the text budget would
+    // time out every single time and make the gate useless.
+    expect(LAYER1_IMAGE_TIMEOUT_MS).toBeGreaterThanOrEqual(8_000);
+  });
+});
+
+describe("handler wiring: the gate receives what the model receives", () => {
+  it("passes resolved images to Layer 1, not just the prompt", async () => {
+    const { runInfer } = await import("../../src/tools/prismInferHandler.js");
+    const { _setCacheForTest, _resetEntitlementsForTest } =
+      await import("../../src/utils/entitlements.js");
+    const ENT: any = {
+      plan: "enterprise", model_ceiling: "27b", daily_infer_limit: 1e5, max_tokens: 4096, max_seats: 25,
+      features: { cloud_fallback: true, grounding_verifier: true, route_guard: true,
+                  knowledge_search_unlimited: true, session_memory_unlimited: true, analytics_dashboard: true },
+      upgrade_url: "https://synalux.ai/pricing",
+    };
+    _setCacheForTest(ENT, 60_000);
+    let sawImages: string[] | undefined;
+    try {
+      await runInfer(
+        { prompt: "describe this", images: [B64], mode: "chat", task_complexity: 5 },
+        {
+          freemem: () => 30 * 1024 ** 3,
+          listTags: async () => new Set(["prism-coder:9b", "prism-coder:4b"]),
+          listLoaded: async () => new Set<string>(),
+          callLocal: async () => ({ ok: true as const, text: "a screen", doneReason: "stop" }),
+          callCloud: async () => ({ ok: false as const, reason: "no" }),
+          ollamaUrl: "http://x",
+          probeVision: async () => true,
+          callLayer1: async (_p, _u, _m, _f, images) => { sawImages = images; return "OBVIOUS_NOT_RESERVED"; },
+        } as any);
+    } finally { _resetEntitlementsForTest(); }
+    expect(sawImages).toEqual([B64]);   // the gate saw the screenshot
+  });
+});


### PR DESCRIPTION
Closes the gap flagged in the #159 review.

`prism_infer` gained image input; the reserved-content classifier did not. It saw the **text prompt only**, so a screenshot of clinical material passed a gate that never looked at it.

- `callLayer1` now accepts and attaches images; they are resolved **before** the gate so it sees exactly what the model will.
- Vision classify gets a **10s** budget (a ~3,000-image-token pass times out on the 1.5s text budget every time — a gate that always errors never gates).
- **Fail-safe:** text ERROR falls through to a keyword backstop that can still read the prompt; an image has no such fallback, so an unclassifiable image maps to **UNCERTAIN** (reserved handling), never silently allowed.

5 new tests, mutation-verified; 3,964 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)