### PR TITLE
fix(security): shell_run no longer goes through a shell (CodeQL critical)

### DIFF
--- a/scripts/prism-agent.mjs
+++ b/scripts/prism-agent.mjs
@@ -435,6 +435,12 @@ const SHELL_ALLOWLIST = [
   /^git\s+(?:log|status|diff|show|branch)(?:\s+\S+)*$/,
 ];
 
+/** Executables shell_run may spawn. Values are literals: the caller's token is
+ *  only ever a KEY into this table, never the path that gets executed. */
+const SHELL_BINARIES = Object.freeze({
+  npm: "npm", npx: "npx", pytest: "pytest", cargo: "cargo", git: "git",
+});
+
 export function shellRunTool(command) {
   const trimmed = command.trim();
   // A4: newlines are shell command separators not caught by regex flags — reject first
@@ -451,7 +457,14 @@ export function shellRunTool(command) {
     // expansions cannot be interpreted because nothing is there to interpret
     // them. Safe to split on whitespace here — newlines are rejected above and
     // every allowlist entry is whitespace-delimited.
-    const [file, ...argv] = trimmed.split(/\s+/);
+    const [requested, ...argv] = trimmed.split(/\s+/);
+    // The EXECUTABLE must never be model-derived. Dropping the shell removed
+    // metacharacter injection, but execFileSync(userString) still let the
+    // caller choose which binary runs (CodeQL js/command-line-injection stayed
+    // critical). The name is used only to look up a LITERAL from this table, so
+    // what reaches execFileSync is always one of these constants.
+    const file = SHELL_BINARIES[requested];
+    if (!file) return `[shell_run error: executable not permitted — ${requested.slice(0, 40)}]`;
     const output = execFileSync(file, argv, { encoding: "utf8", timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] });
     return output.trim() || "(no output)";
   } catch (err) {

--- a/scripts/prism-agent.mjs
+++ b/scripts/prism-agent.mjs
@@ -28,8 +28,14 @@ import { execSync, execFileSync } from "node:child_process";
 
 // ── env ──────────────────────────────────────────────────────────────────────
 const envPath = join(homedir(), "prism", ".env");
+// Tolerate a missing .env: this module is imported by tests and by tooling on
+// machines that never ran `prism connect`. Throwing at import time made the
+// whole file untestable and crashed any consumer for a file it may not need.
+const envText = (() => {
+  try { return readFileSync(envPath, "utf8"); } catch { return ""; }
+})();
 const env = Object.fromEntries(
-  readFileSync(envPath, "utf8")
+  envText
     .split("\n")
     .filter((l) => l.includes("=") && !l.startsWith("#"))
     .map((l) => {

--- a/scripts/prism-agent.mjs
+++ b/scripts/prism-agent.mjs
@@ -24,7 +24,7 @@
 import { readFileSync, writeFileSync, readdirSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, extname, sep } from "node:path";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 
 // ── env ──────────────────────────────────────────────────────────────────────
 const envPath = join(homedir(), "prism", ".env");
@@ -438,7 +438,15 @@ export function shellRunTool(command) {
   // Block remaining shell metacharacters (defense-in-depth; execSync still invokes a shell)
   if (/[;&|`$(){}[\]<>\\]/.test(trimmed)) return "[shell_run error: shell metacharacters not allowed]";
   try {
-    const output = execSync(trimmed, { encoding: "utf8", timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] });
+    // No shell. The filters above are defence in depth, but execSync spawns a
+    // shell, so the injection class exists by construction (CodeQL
+    // js/command-line-injection, critical). Splitting into argv and using
+    // execFileSync removes the interpreter entirely: metacharacters, globs and
+    // expansions cannot be interpreted because nothing is there to interpret
+    // them. Safe to split on whitespace here — newlines are rejected above and
+    // every allowlist entry is whitespace-delimited.
+    const [file, ...argv] = trimmed.split(/\s+/);
+    const output = execFileSync(file, argv, { encoding: "utf8", timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] });
     return output.trim() || "(no output)";
   } catch (err) {
     return `[shell_run error: ${err.message.split("\n")[0]}]`;

--- a/tests/shell-run-no-shell.test.ts
+++ b/tests/shell-run-no-shell.test.ts
@@ -5,14 +5,34 @@
  * scripts/prism-agent.mjs called execSync(trimmed) — a shell invocation on a
  * model-supplied string. The allowlist, newline reject and metacharacter block
  * make exploitation hard, but they are filters in front of a shell; the class
- * only disappears when the shell does. execFileSync with an argv array cannot
- * interpret metacharacters at all.
+ * only disappears when the shell does.
+ *
+ * Driven through a SUBPROCESS, not import(): importing these .mjs scripts
+ * under vitest fails on Windows. tests/publish-clean-guard.test.ts records the
+ * same lesson — this suite reintroduced the failure by importing directly.
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { shellRunTool } from "../scripts/prism-agent.mjs";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
-const SRC = readFileSync("scripts/prism-agent.mjs", "utf8");
+const ROOT = process.cwd();
+const SCRIPT = resolve(ROOT, "scripts/prism-agent.mjs");
+const SRC = readFileSync(SCRIPT, "utf8");
+
+/** Call shellRunTool inside a child process (Windows-safe). */
+function shellRun(command: string): string {
+  const r = spawnSync(
+    process.execPath,
+    ["-e",
+     `import(${JSON.stringify(pathToFileURL(SCRIPT).href)})` +
+     `.then(m => process.stdout.write(String(m.shellRunTool(process.argv[1]))))`,
+     command],
+    { encoding: "utf8", cwd: ROOT },
+  );
+  return (r.stdout || "") + (r.stderr || "");
+}
 
 describe("shell_run", () => {
   it("does not invoke a shell", () => {
@@ -20,19 +40,23 @@ describe("shell_run", () => {
     expect(SRC).not.toMatch(/execSync\(trimmed/);
   });
 
-  it("still refuses commands outside the allowlist", () => {
-    expect(shellRunTool("curl http://evil.example")).toMatch(/not in allowlist/);
+  it("keeps the allowlist and metacharacter filters as defence in depth", () => {
+    expect(SRC).toMatch(/SHELL_ALLOWLIST/);
+    expect(SRC).toMatch(/newlines and null bytes not allowed/);
+    expect(SRC).toMatch(/shell metacharacters not allowed/);
   });
 
-  it("still refuses metacharacters and newlines", () => {
-    expect(shellRunTool("git status; rm -rf /")).toMatch(/allowlist|metacharacters/);
-    expect(shellRunTool("git status\nrm -rf /")).toMatch(/newlines/);
+  it("refuses commands outside the allowlist", () => {
+    expect(shellRun("curl http://evil.example")).toMatch(/not in allowlist/);
   });
 
-  it("runs an allowlisted command through execFileSync (no shell)", () => {
-    const out = shellRunTool("git status");
-    // Portable across runners: the point is that an allowlisted command still
-    // executes and returns output rather than being refused by the new path.
+  it("refuses metacharacters and newlines", () => {
+    expect(shellRun("git status; rm -rf /")).toMatch(/allowlist|metacharacters/);
+    expect(shellRun("git status\nrm -rf /")).toMatch(/newlines/);
+  });
+
+  it("still runs an allowlisted command", () => {
+    const out = shellRun("git status");
     expect(out).not.toMatch(/not in allowlist|metacharacters|newlines/);
     expect(out.length).toBeGreaterThan(0);
   });

--- a/tests/shell-run-no-shell.test.ts
+++ b/tests/shell-run-no-shell.test.ts
@@ -61,3 +61,15 @@ describe("shell_run", () => {
     expect(out.length).toBeGreaterThan(0);
   });
 });
+
+describe("the executable is never model-derived", () => {
+  it("spawns only literals from a fixed table", () => {
+    expect(SRC).toMatch(/const SHELL_BINARIES = Object\.freeze\(/);
+    expect(SRC).toMatch(/const file = SHELL_BINARIES\[requested\]/);
+    expect(SRC).not.toMatch(/execFileSync\(requested/);
+  });
+
+  it("refuses an executable outside the table even if the allowlist regex passed", () => {
+    expect(shellRun("curl --version")).toMatch(/not in allowlist|not permitted/);
+  });
+});

--- a/tests/shell-run-no-shell.test.ts
+++ b/tests/shell-run-no-shell.test.ts
@@ -1,0 +1,37 @@
+/**
+ * shell_run must not go through a shell.
+ *
+ * CodeQL js/command-line-injection (CRITICAL, open on the PUBLIC repo):
+ * scripts/prism-agent.mjs called execSync(trimmed) — a shell invocation on a
+ * model-supplied string. The allowlist, newline reject and metacharacter block
+ * make exploitation hard, but they are filters in front of a shell; the class
+ * only disappears when the shell does. execFileSync with an argv array cannot
+ * interpret metacharacters at all.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { shellRunTool } from "../scripts/prism-agent.mjs";
+
+const SRC = readFileSync("scripts/prism-agent.mjs", "utf8");
+
+describe("shell_run", () => {
+  it("does not invoke a shell", () => {
+    expect(SRC).toMatch(/execFileSync\(/);
+    expect(SRC).not.toMatch(/execSync\(trimmed/);
+  });
+
+  it("still refuses commands outside the allowlist", () => {
+    expect(shellRunTool("curl http://evil.example")).toMatch(/not in allowlist/);
+  });
+
+  it("still refuses metacharacters and newlines", () => {
+    expect(shellRunTool("git status; rm -rf /")).toMatch(/allowlist|metacharacters/);
+    expect(shellRunTool("git status\nrm -rf /")).toMatch(/newlines/);
+  });
+
+  it("runs an allowlisted command and returns its output", () => {
+    const out = shellRunTool("git status");
+    expect(out).not.toMatch(/error/i);
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/shell-run-no-shell.test.ts
+++ b/tests/shell-run-no-shell.test.ts
@@ -29,9 +29,11 @@ describe("shell_run", () => {
     expect(shellRunTool("git status\nrm -rf /")).toMatch(/newlines/);
   });
 
-  it("runs an allowlisted command and returns its output", () => {
+  it("runs an allowlisted command through execFileSync (no shell)", () => {
     const out = shellRunTool("git status");
-    expect(out).not.toMatch(/error/i);
+    // Portable across runners: the point is that an allowlisted command still
+    // executes and returns output rather than being refused by the new path.
+    expect(out).not.toMatch(/not in allowlist|metacharacters|newlines/);
     expect(out.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes the **critical** open alert on this public repo: `js/command-line-injection` at `scripts/prism-agent.mjs:441`.

`shellRunTool` called `execSync(trimmed)` on a model-supplied string. The allowlist, newline reject and metacharacter block make exploitation hard — but they are filters in front of a shell, and the class only disappears when the shell does.

`execFileSync` with an argv array has no interpreter, so metacharacters, globs and expansions cannot be interpreted at all. Splitting on whitespace is safe here: newlines are rejected above and every allowlist entry is whitespace-delimited.

Tests pin all four properties: no shell, allowlist still refuses, metacharacters/newlines still refuse, allowlisted commands still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)