### PR TITLE
fix(infer): review findings on the image + Layer 1 path

### DIFF
--- a/src/tools/prismInferHandler.ts
+++ b/src/tools/prismInferHandler.ts
@@ -93,6 +93,23 @@ const MAX_ROUTE_TOOLS = 64;
 
 // ─── Tool Definition ────────────────────────────────────────────
 
+export const MAX_INFER_IMAGES = 8;
+/** Bytes per supplied image. Beyond this the base64 blows request memory and
+ *  the tier timeout before the model ever sees it. */
+export const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+/** Aggregate cap across all images in one call. The per-image limit alone
+ *  still allows 8 x 12MB = 96MB of base64 in memory for a single request. */
+export const MAX_IMAGE_BYTES_TOTAL = 24 * 1024 * 1024;
+/** Prompt-token cost of ONE image. Measured live 2026-08-14: a 1206x2622
+ *  screenshot produced tokens=3156in against a ~30-token prompt. The 9b/27b
+ *  tiers advertise ctxTokens 4_096, so this MUST be charged to the context
+ *  gate — counting only the text prompt let two images silently overflow. */
+export const IMAGE_TOKEN_ESTIMATE = 3_000;
+
+export function estimateImageTokens(count: number): number {
+    return Math.max(0, count) * IMAGE_TOKEN_ESTIMATE;
+}
+
 export const PRISM_INFER_TOOL: Tool = {
     name: "prism_infer",
     description:
@@ -112,7 +129,7 @@ export const PRISM_INFER_TOOL: Tool = {
             images: {
                 type: "array",
                 items: { type: "string" },
-                maxItems: 8,
+                maxItems: MAX_INFER_IMAGES,
                 description:
                     "Screenshots or frames to analyse. Each entry is an absolute file path " +
                     "or raw base64. Requires a vision-capable tier; tiers without vision are " +
@@ -519,19 +536,6 @@ interface OllamaChatResp {
     eval_count?: number;
 }
 
-export const MAX_INFER_IMAGES = 8;
-/** Bytes per supplied image. Beyond this the base64 blows request memory and
- *  the tier timeout before the model ever sees it. */
-export const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
-/** Prompt-token cost of ONE image. Measured live 2026-08-14: a 1206x2622
- *  screenshot produced tokens=3156in against a ~30-token prompt. The 9b/27b
- *  tiers advertise ctxTokens 4_096, so this MUST be charged to the context
- *  gate — counting only the text prompt let two images silently overflow. */
-export const IMAGE_TOKEN_ESTIMATE = 3_000;
-
-export function estimateImageTokens(count: number): number {
-    return Math.max(0, count) * IMAGE_TOKEN_ESTIMATE;
-}
 
 /** Resolve caller-supplied images to raw base64.
  *  A filesystem path is read and encoded; anything else is assumed to be
@@ -541,6 +545,7 @@ export function estimateImageTokens(count: number): number {
 export async function prepareImages(images: string[]): Promise<string[]> {
     const fs = await import("node:fs/promises");
     const out: string[] = [];
+    let totalBytes = 0;
     for (const entry of images) {
         // Windows drive paths (C:\\...) and UNC (\\\\server\\share) are paths too;
         // treating them as base64 sends a filename as image bytes.
@@ -559,6 +564,10 @@ export async function prepareImages(images: string[]): Promise<string[]> {
                         throw new Error(`image too large: ${(stat.size / 1024 / 1024).toFixed(1)}MB > ${MAX_IMAGE_BYTES / 1024 / 1024}MB`);
                     }
                     const buf = await handle.readFile();
+                    totalBytes += stat.size;
+                    if (totalBytes > MAX_IMAGE_BYTES_TOTAL) {
+                        throw new Error(`images too large in aggregate: > ${MAX_IMAGE_BYTES_TOTAL / 1024 / 1024}MB across ${images.length} images`);
+                    }
                     out.push(buf.toString("base64"));
                 } finally {
                     await handle.close();
@@ -1120,6 +1129,30 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
     if (installed && !layer1RecursionGuard) {
         const l1fn = deps.callLayer1 ?? defaultCallLayer1;
         const l1Model = resolveOllamaName("prism-coder:4b", installed);
+        // The classifier must be able to SEE what it is classifying. Ollama
+        // accepts `images` on a text-only model and silently ignores them
+        // (measured 2026-08-14), so passing them is not enough — a blind
+        // classifier would return a confident verdict about a screenshot it
+        // never received. Verify capability; refuse rather than pretend.
+        if (resolvedImages?.length) {
+            let classifierSees = false;
+            try {
+                classifierSees = l1Model ? await (deps.probeVision ?? probeVision)(deps.ollamaUrl, l1Model) : false;
+            } catch {
+                classifierSees = false;   // unprobeable → treat as blind
+            }
+            if (!classifierSees) {
+                attempts.push({ tier: "layer1", reason: "layer1_classifier_no_vision" });
+                // Same contract as every other safety refusal here: report mode
+                // returns a structured outcome instead of throwing.
+                if (wantReport) return refusedResult("layer1_classifier_no_vision");
+                throw new Error(
+                    `prism_infer: the Layer 1 classifier (${l1Model ?? "prism-coder:4b"}) cannot process images, ` +
+                    `so image content cannot be safety-classified. Refusing rather than classifying the prompt alone. ` +
+                    `Rebuild the classifier with a vision tower to enable image requests.`
+                );
+            }
+        }
         // 4th arg is fetchImpl (default), 5th is the images the classifier must see.
         const l1 = await l1fn(args.prompt, deps.ollamaUrl, l1Model, undefined, resolvedImages);
         if (l1 === "OBVIOUS_RESERVED" || l1 === "UNCERTAIN") {

--- a/tests/tools/infer-images.test.ts
+++ b/tests/tools/infer-images.test.ts
@@ -130,7 +130,9 @@ describe("infer chain with screenshots", () => {
     const r = await runInfer(
       { prompt: "what is occluded?", images: [B64], mode: "chat", task_complexity: 5 },
       deps({
-        probeVision: async (_u, m) => m.includes("9b"),
+        // The 4b classifier must see too — Layer 1 now refuses to classify an
+        // image it cannot look at, so a happy-path mock has to grant it vision.
+        probeVision: async () => true,
         callLocal: async (_u, _m, _p, _s, _mt, _t, _to, _th, images) => {
           seen.push(images);
           return { ok: true as const, text: "YES — Sources & Citations", doneReason: "stop" };
@@ -201,5 +203,32 @@ describe("round-3 review: security + privacy", () => {
         callCloud: async () => { cloudCalls++; return { ok: true as const, text: "cloud answer", backend: "gemini" } as any; },
       }))).rejects.toThrow();
     expect(cloudCalls).toBe(0);   // image content stays on-device AND no blind answer
+  });
+});
+
+describe("round-5 review findings", () => {
+  it("caps images in AGGREGATE, not just per image", async () => {
+    const { prepareImages, MAX_IMAGE_BYTES_TOTAL } = await import("../../src/tools/prismInferHandler.js");
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const dir = mkdtempSync(join(tmpdir(), "infer-agg-"));
+    // Each file is under the per-image cap; together they exceed the total.
+    const paths: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const p = join(dir, `a${i}.png`);
+      writeFileSync(p, Buffer.alloc(8 * 1024 * 1024));
+      paths.push(p);
+    }
+    expect(4 * 8 * 1024 * 1024).toBeGreaterThan(MAX_IMAGE_BYTES_TOTAL);
+    await expect(prepareImages(paths)).rejects.toThrow(/aggregate/i);
+  });
+
+  it("derives the schema's maxItems from the constant so they cannot drift", async () => {
+    const { MAX_INFER_IMAGES } = await import("../../src/tools/prismInferHandler.js");
+    const src = await import("node:fs").then(fs =>
+      fs.readFileSync("src/tools/prismInferHandler.ts", "utf8"));
+    expect(src).toMatch(/maxItems: MAX_INFER_IMAGES/);
+    expect(MAX_INFER_IMAGES).toBe(8);
   });
 });

--- a/tests/tools/layer1-images.test.ts
+++ b/tests/tools/layer1-images.test.ts
@@ -81,3 +81,109 @@ describe("handler wiring: the gate receives what the model receives", () => {
     expect(sawImages).toEqual([B64]);   // the gate saw the screenshot
   });
 });
+
+describe("round-1 review: the classifier must actually be able to see", () => {
+  it("a TEXT-ONLY classifier + images = UNCERTAIN, never a text-only verdict", async () => {
+    // Measured 2026-08-14: ollama accepts `images` on a text-only model and
+    // silently ignores them — no error. So on any machine whose 4b has not
+    // been rebuilt with a vision tower, Layer 1 would classify the PROMPT and
+    // report a confident verdict about a screenshot it never saw. Passing the
+    // images is not enough; the classifier's capability must be verified.
+    const { runInfer } = await import("../../src/tools/prismInferHandler.js");
+    const { _setCacheForTest, _resetEntitlementsForTest } = await import("../../src/utils/entitlements.js");
+    const ENT: any = {
+      plan: "enterprise", model_ceiling: "27b", daily_infer_limit: 1e5, max_tokens: 4096, max_seats: 25,
+      features: { cloud_fallback: false, grounding_verifier: false, route_guard: false,
+                  knowledge_search_unlimited: true, session_memory_unlimited: true, analytics_dashboard: false },
+      upgrade_url: "https://synalux.ai/pricing",
+    };
+    _setCacheForTest(ENT, 60_000);
+    let l1Called = false;
+    try {
+      const run = runInfer(
+        { prompt: "what is on this screen?", images: [B64], mode: "chat", task_complexity: 5 },
+        {
+          freemem: () => 30 * 1024 ** 3,
+          listTags: async () => new Set(["prism-coder:9b", "prism-coder:4b"]),
+          listLoaded: async () => new Set<string>(),
+          callLocal: async () => ({ ok: true as const, text: "a screen", doneReason: "stop" }),
+          callCloud: async () => ({ ok: false as const, reason: "off" }),
+          ollamaUrl: "http://x",
+          // 9b can see; the CLASSIFIER (4b) cannot.
+          probeVision: async (_u: string, m: string) => !m.includes("4b"),
+          callLayer1: async () => { l1Called = true; return "OBVIOUS_NOT_RESERVED"; },
+        } as any);
+      await expect(run).rejects.toThrow(/classifier|vision|reserved/i);
+    } finally { _resetEntitlementsForTest(); }
+    expect(l1Called).toBe(false);   // never trusted a blind classifier
+  });
+});
+
+describe("round-3 review: safety refusals honour escalation:'report'", () => {
+  it("returns a structured refusal instead of throwing when report mode is on", async () => {
+    // Every other safety refusal in this handler returns refusedResult() under
+    // escalation:'report'. The blind-classifier refusal threw, breaking that
+    // contract for callers that opted into structured outcomes.
+    const { runInfer } = await import("../../src/tools/prismInferHandler.js");
+    const { _setCacheForTest, _resetEntitlementsForTest } = await import("../../src/utils/entitlements.js");
+    const ENT: any = {
+      plan: "enterprise", model_ceiling: "27b", daily_infer_limit: 1e5, max_tokens: 4096, max_seats: 25,
+      features: { cloud_fallback: false, grounding_verifier: false, route_guard: false,
+                  knowledge_search_unlimited: true, session_memory_unlimited: true, analytics_dashboard: false },
+      upgrade_url: "https://synalux.ai/pricing",
+    };
+    _setCacheForTest(ENT, 60_000);
+    try {
+      const r: any = await runInfer(
+        { prompt: "what is on this screen?", images: [B64], mode: "chat", task_complexity: 5, escalation: "report" },
+        {
+          freemem: () => 30 * 1024 ** 3,
+          listTags: async () => new Set(["prism-coder:9b", "prism-coder:4b"]),
+          listLoaded: async () => new Set<string>(),
+          callLocal: async () => ({ ok: true as const, text: "x", doneReason: "stop" }),
+          callCloud: async () => ({ ok: false as const, reason: "off" }),
+          ollamaUrl: "http://x",
+          probeVision: async (_u: string, m: string) => !m.includes("4b"),
+          callLayer1: async () => "OBVIOUS_NOT_RESERVED",
+        } as any);
+      // Structured refusal lives on gate_outcome, matching every other
+      // safety refusal in this handler.
+      expect(r.gate_outcome?.status).toBe("refused");
+      expect(r.gate_outcome?.reason).toBe("layer1_classifier_no_vision");
+      expect(r.output).toBe("");
+    } finally { _resetEntitlementsForTest(); }
+  });
+});
+
+describe("round-4 review: an unprobeable classifier is blind, not trusted", () => {
+  it("refuses when the vision probe itself fails", async () => {
+    // Mutation testing found this path untested: flipping the catch to
+    // `classifierSees = true` (fail open) kept every test green. If we cannot
+    // establish that the classifier can see, we must not let the image past.
+    const { runInfer } = await import("../../src/tools/prismInferHandler.js");
+    const { _setCacheForTest, _resetEntitlementsForTest } = await import("../../src/utils/entitlements.js");
+    const ENT: any = {
+      plan: "enterprise", model_ceiling: "27b", daily_infer_limit: 1e5, max_tokens: 4096, max_seats: 25,
+      features: { cloud_fallback: false, grounding_verifier: false, route_guard: false,
+                  knowledge_search_unlimited: true, session_memory_unlimited: true, analytics_dashboard: false },
+      upgrade_url: "https://synalux.ai/pricing",
+    };
+    _setCacheForTest(ENT, 60_000);
+    try {
+      const r: any = await runInfer(
+        { prompt: "what is on this screen?", images: [B64], mode: "chat", task_complexity: 5, escalation: "report" },
+        {
+          freemem: () => 30 * 1024 ** 3,
+          listTags: async () => new Set(["prism-coder:9b", "prism-coder:4b"]),
+          listLoaded: async () => new Set<string>(),
+          callLocal: async () => ({ ok: true as const, text: "x", doneReason: "stop" }),
+          callCloud: async () => ({ ok: false as const, reason: "off" }),
+          ollamaUrl: "http://x",
+          probeVision: async () => { throw new Error("ollama unreachable"); },
+          callLayer1: async () => "OBVIOUS_NOT_RESERVED",
+        } as any);
+      expect(r.gate_outcome?.status).toBe("refused");
+      expect(r.gate_outcome?.reason).toBe("layer1_classifier_no_vision");
+    } finally { _resetEntitlementsForTest(); }
+  });
+});


### PR DESCRIPTION
Findings from the adversarial review rounds after #159/#160 merged.

**Round 1 — the image gate was still open.** Ollama accepts `images` on a text-only model and **silently ignores them** (measured). So on any machine whose 4b classifier lacks a vision tower — every user, since the rebuilds aren't published — Layer 1 judged the *prompt* and returned a confident verdict about a screenshot it never saw. The classifier's capability is now verified; blind or unprobeable ⇒ refuse.

**Round 3 — that refusal threw**, breaking the `escalation:'report'` contract every other safety refusal here honours. Now returns `refusedResult()`.

**Round 4 — mutation testing found the fail-safe untested**: flipping the probe's catch to fail *open* kept every test green. Pinned.

**Round 5 — images were capped per-file but not in aggregate** (8 × 12 MB = 96 MB), and the schema's `maxItems` was a literal that could drift from `MAX_INFER_IMAGES`. Both closed.

27 tests in the two image suites; full suite 4,003 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)