### PR TITLE
fix(infer): read num_ctx from the model, not from a table that goes stale

### DIFF
--- a/src/tools/prismInferHandler.ts
+++ b/src/tools/prismInferHandler.ts
@@ -695,6 +695,56 @@ export async function tiersSupportingVision(
     return keep;
 }
 
+/**
+ * Effective context window for a tag, read from the model itself.
+ *
+ * MODEL_TIERS.ctxTokens is a MIRROR of each Modelfile's `num_ctx`, and a mirror
+ * goes stale silently. It did: the 2026-08-14 vision push republished
+ * prism-coder:9b with no PARAMETER lines at all, so the table kept declaring
+ * 4_096 while Ollama granted its own larger default. The §5.4 gate then refused
+ * that tier — and the 27b above it — for prompts it demonstrably serves,
+ * measured at 18,575 tokens answered rather than truncated, and fell through to
+ * 4b/2b instead.
+ *
+ * `/api/show` returns the pinned value under `parameters` when the Modelfile
+ * declares one. Measured across the fleet:
+ *
+ *   prism-coder:4b   num_ctx 32768   pinned
+ *   prism-coder:2b   num_ctx 32768   pinned
+ *   prism-coder:27b  num_ctx  4096   pinned
+ *   prism-coder:9b   ABSENT          <- exactly the tag whose packaging broke
+ *
+ * So the live read is authoritative wherever packaging is intact, and reports
+ * nothing precisely where it is not. Returning null on absence lets the caller
+ * keep the conservative table value, which keeps the failure mode fail-SAFE: an
+ * unpinned tier is under-declared and merely loses work, instead of being
+ * over-declared and silently truncating a prompt.
+ *
+ * `model_info["<arch>.context_length"]` is deliberately NOT used as a fallback.
+ * That is the architecture's maximum — 262144 for qwen35 — not what the runtime
+ * grants, and trusting it would turn every unpinned tier fail-open.
+ *
+ * Adopting scripts/prism-coder-9b.Modelfile therefore unlocks the 9b on its own,
+ * with no code change and no second edit to remember.
+ */
+export async function probeNumCtx(url: string, model: string): Promise<number | null> {
+    try {
+        const res = await fetch(`${url}/api/show`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ model }),
+            signal: AbortSignal.timeout(5_000),
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as { parameters?: string };
+        const m = /^\s*num_ctx\s+(\d+)\s*$/m.exec(data.parameters ?? "");
+        const n = m ? Number(m[1]) : NaN;
+        return Number.isFinite(n) && n > 0 ? n : null;
+    } catch {
+        return null; // unreachable or unparseable -> fall back to the table
+    }
+}
+
 /** Default vision probe: /api/show reports capabilities for the local model. */
 export async function probeVision(url: string, model: string): Promise<boolean> {
     const res = await fetch(`${url}/api/show`, {
@@ -1036,6 +1086,8 @@ export interface InferDeps {
     entitlements?: PrismEntitlements;
     /** Injectable vision probe for testing. Defaults to probeVision (/api/show). */
     probeVision?: (url: string, model: string) => Promise<boolean>;
+    /** Injectable context probe for testing. Defaults to probeNumCtx (/api/show). */
+    probeNumCtx?: (url: string, model: string) => Promise<number | null>;
     /** Injectable Layer 1 classifier for testing. Defaults to callLayer1 from layer1.ts. */
     callLayer1?: (userPrompt: string, ollamaUrl: string, model: string, fetchImpl?: typeof fetch, images?: string[]) => Promise<Layer1Verdict>;
 }
@@ -1648,8 +1700,30 @@ export async function runInfer(args: PrismInferArgs, deps: InferDeps): Promise<P
             const promptTokensEst = estimateImageTokens(resolvedImages?.length ?? 0) + estimateTokens(args.prompt)
                 + (effectiveSystem ? estimateTokens(effectiveSystem) : 0)
                 + CTX_TEMPLATE_MARGIN;
-            if (promptTokensEst > tier.ctxTokens) {
-                attempts.push({ tier: tier.tag, reason: "ctx_insufficient" });
+            // Prefer what the model reports over what the table remembers. A
+            // tag with a pinned num_ctx is authoritative; one without keeps the
+            // table's conservative value, so an unpinned tier can only LOSE work,
+            // never silently truncate. See probeNumCtx.
+            // Wrapped, not just trusted. The default probeNumCtx catches its own
+            // failures, but an INJECTED probe (tests, or a future variant) may
+            // throw — and an exception here would abort the whole tier walk on a
+            // diagnostic lookup, turning "could not read num_ctx" into a failed
+            // request. Same fail-safe the eviction and vision probe sites use:
+            // unprobeable means fall back to the table, never unlock.
+            let liveCtx: number | null = null;
+            try {
+                liveCtx = await (deps.probeNumCtx ?? probeNumCtx)(deps.ollamaUrl, ollamaName);
+            } catch {
+                liveCtx = null;
+            }
+            const effectiveCtx = liveCtx ?? tier.ctxTokens;
+            if (promptTokensEst > effectiveCtx) {
+                attempts.push({
+                    tier: tier.tag,
+                    reason: liveCtx && liveCtx !== tier.ctxTokens
+                        ? `ctx_insufficient:live_${liveCtx}`
+                        : "ctx_insufficient",
+                });
                 continue;
             }
             if (visionOk && !visionOk.has(ollamaName)) {

--- a/tests/tools/inferLiveCtxGate.test.ts
+++ b/tests/tools/inferLiveCtxGate.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { runInfer, type InferDeps, type PrismInferArgs } from "../../src/tools/prismInferHandler.js";
+import { _setCacheForTest, _resetEntitlementsForTest, type PrismEntitlements } from "../../src/utils/entitlements.js";
+
+/**
+ * The ctx gate must believe the MODEL, not the table — but only when the model
+ * actually says something.
+ *
+ * MODEL_TIERS.ctxTokens mirrors each Modelfile's num_ctx, and that mirror went
+ * stale: the 2026-08-14 vision push republished prism-coder:9b with no PARAMETER
+ * lines, so the table kept declaring 4_096 while Ollama granted more. Measured
+ * through the real MCP path, a ~6k-token prompt produced:
+ *
+ *   attempts=[{27b, ctx_insufficient}, {9b, ctx_insufficient}] -> backend=ollama-4b
+ *
+ * The two best tiers refused work they could do, on a prompt the 9b answers at
+ * 18,575 tokens without truncation. That is the entire reason the local path
+ * under-performed on large inputs.
+ *
+ * The fix reads num_ctx live. The asymmetry is the point and is what these tests
+ * pin: a pinned value is trusted in BOTH directions, and an absent one falls
+ * back to the table rather than to the architecture maximum. Absent means "this
+ * tag's packaging is broken" — which is exactly when guessing high would
+ * silently truncate a prompt, the failure §5.4 exists to prevent.
+ */
+
+const GB = 1024 ** 3;
+
+const ENT: PrismEntitlements = {
+    plan: "enterprise",
+    model_ceiling: "27b",
+    daily_infer_limit: 100000,
+    max_tokens: 4096,
+    max_seats: 25,
+    features: {
+        cloud_fallback: false,
+        grounding_verifier: false,
+        knowledge_search_unlimited: true,
+        session_memory_unlimited: true,
+        analytics_dashboard: true,
+    },
+    upgrade_url: "https://synalux.ai/pricing",
+};
+
+beforeEach(() => _setCacheForTest(ENT, 60_000));
+afterAll(() => _resetEntitlementsForTest());
+
+/** ~6k tokens: far above the table's 4_096 for the 9b, far below a pinned 32_768. */
+const BIG_PROMPT = "x".repeat(24_000);
+
+function makeDeps(
+    served: string[],
+    liveCtx: (model: string) => number | null,
+    installed: string[],
+): InferDeps {
+    return {
+        freemem: () => 30 * GB,
+        listTags: async () => new Set(installed),
+        listLoaded: async () => new Set<string>(),
+        callLocal: async (_u, model) => {
+            served.push(model);
+            return { ok: true as const, text: "a sufficiently long answer", doneReason: "stop" };
+        },
+        callCloud: async () => ({ ok: false as const, reason: "no_cloud" }),
+        ollamaUrl: "http://localhost:11434",
+        callLayer1: async () => "OBVIOUS_NOT_RESERVED",
+        probeNumCtx: async (_u, model) => liveCtx(model),
+    };
+}
+
+const args = (): PrismInferArgs => ({ prompt: BIG_PROMPT, mode: "code", escalation: "report" });
+
+describe("the ctx gate prefers the live num_ctx over the table", () => {
+    it("a tier whose Modelfile PINS a large ctx is used, even though the table says 4_096", async () => {
+        const served: string[] = [];
+        // 9b reports 32_768 — what scripts/prism-coder-9b.Modelfile pins.
+        await runInfer(args(), makeDeps(served, () => 32_768, ["prism-coder:9b", "prism-coder:4b"]));
+
+        expect(served[0], "the 9b was skipped despite reporting a 32k window").toBe("prism-coder:9b");
+    });
+
+    it("a tier reporting NOTHING keeps the table's conservative value and is skipped", async () => {
+        const served: string[] = [];
+        // This is prism-coder:9b as currently published: parameters absent.
+        const r = await runInfer(args(), makeDeps(served, () => null, ["prism-coder:9b", "prism-coder:4b"]));
+
+        expect(served[0], "an unpinned tier was trusted with an oversize prompt").toBe("prism-coder:4b");
+        expect(r.attempts.some(a => a.tier.includes("9b") && a.reason.startsWith("ctx_insufficient"))).toBe(true);
+    });
+
+    it("a live value SMALLER than the table also wins — the model is authoritative both ways", async () => {
+        const served: string[] = [];
+        // 4b's table row says 32_768; pretend its Modelfile was republished at 2_048.
+        const r = await runInfer(
+            args(),
+            makeDeps(served, (m) => (m.includes("4b") ? 2_048 : null), ["prism-coder:4b", "prism-coder:2b"]),
+        );
+
+        expect(served[0], "trusted the table over a smaller pinned value — would truncate").toBe("prism-coder:2b");
+        expect(
+            r.attempts.some(a => a.tier.includes("4b") && a.reason === "ctx_insufficient:live_2048"),
+            "the reason should name the live value, so a stale table is visible in the trace",
+        ).toBe(true);
+    });
+
+    it("a probe that throws is treated as absent, not as permission", async () => {
+        const served: string[] = [];
+        await runInfer(
+            args(),
+            {
+                ...makeDeps(served, () => null, ["prism-coder:9b", "prism-coder:4b"]),
+                probeNumCtx: async () => { throw new Error("ollama unreachable"); },
+            },
+        );
+
+        expect(served[0], "a failed probe must not unlock an under-declared tier").toBe("prism-coder:4b");
+    });
+});


### PR DESCRIPTION
The local path was refusing work it could do. Measured on `main` through the real MCP path with a ~6k-token prompt:

```
attempts=[{27b, ctx_insufficient}, {9b, ctx_insufficient}] -> backend=ollama-4b
         tokens=14922in/7out
```

Both capable tiers refused, it fell to the 4B, and the answer degraded. Forcing `model_ceiling:"9b"` changed nothing — **the 9B was unreachable for any prompt over ~4k tokens**, which is exactly the workload the local path exists for.

Worth stating plainly: the 40/40 file-survey result measured earlier reached the 9B only by calling Ollama **directly**. It was not reproducible through `prism_infer`.

## Cause

`MODEL_TIERS.ctxTokens` **mirrors** each Modelfile's `num_ctx`, and the mirror went stale. The 2026-08-14 vision push republished `prism-coder:9b` with no `PARAMETER` lines, so the table kept declaring `4_096` while Ollama granted more — a live **18,575-token** prompt is answered, not truncated.

## Why not just raise the number

That is fail-open on any host that hasn't adopted the Modelfile, or whose Ollama defaults lower — an oversize prompt gets silently truncated, the exact failure §5.4 exists to prevent. It would also re-arm the same staleness a release later.

## The fix

The gate asks the model. `/api/show` reports the pinned value under `parameters`:

| tag | `num_ctx` |
|---|---|
| `prism-coder:4b` | 32768 pinned |
| `prism-coder:2b` | 32768 pinned |
| `prism-coder:27b` | 4096 pinned |
| **`prism-coder:9b`** | **ABSENT** ← exactly the tag whose packaging broke |

- **Absent means unknown, not permission.** The tier keeps the table's conservative value, so broken packaging can only lose work, never truncate silently.
- **`model_info["<arch>.context_length"]` is deliberately unused** as a fallback — that's the architecture ceiling (262144 for qwen35), and trusting it would make every unpinned tier fail-open.
- **The live value wins in both directions.** A Modelfile republished *smaller* than the table is the more dangerous drift and is now caught; the skip reason carries the live number (`ctx_insufficient:live_2048`) so a stale table is visible in the trace rather than inferred.

## Consequence

Adopting `scripts/prism-coder-9b.Modelfile` now unlocks the 9B **by itself** — no code change, no second edit for anyone to remember. That coupling is what made the previous fix incomplete.

## Tests

Four, covering the asymmetry in both directions plus the unknown case. One of them caught a real defect while being written: an injected probe that throws would have aborted the whole tier walk on a diagnostic lookup, so the call is now wrapped as well as internally guarded.

`tsc` clean · **4,145 tests pass**.