### PR TITLE
fix(browser): a crashed run must not lock every later run out of the profile

### DIFF
--- a/scripts/dev/browse.py
+++ b/scripts/dev/browse.py
@@ -52,6 +52,7 @@ import select
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -111,6 +112,63 @@ def validate_profile_name(profile: str) -> str:
             "Profile names must be 1-64 characters using letters, numbers, '.', '_' or '-'."
         )
     return profile
+
+
+def clear_stale_singleton_locks(profile_dir) -> bool:
+    """Remove Chrome's singleton files when the process that made them is gone.
+
+    Chrome guards a user-data-dir with `SingletonLock`, a symlink whose target is
+    `<hostname>-<pid>`. A clean exit removes it; a crash does not. The leftover then
+    fails every LATER launch against that profile, so a single crash becomes a
+    permanent outage for every process sharing the profile -- measured 2026-08-16,
+    where one crashed run left `SingletonLock -> Dmitris-MBP-25638` and each
+    subsequent run inherited the failure until the file was removed by hand.
+
+    Only a provably dead owner is cleared:
+
+      * the hostname recorded in the link must be this host, because a pid from
+        another machine says nothing about a local process, and
+      * the pid must not exist -- `os.kill(pid, 0)` raising ProcessLookupError.
+
+    A live lock is left strictly alone. Another agent may legitimately be driving
+    that profile, and stealing its lock would corrupt a running session; on this
+    machine several sessions share one profile, which is exactly how the crash
+    spread. PermissionError means the pid exists under another uid, so it also
+    counts as alive.
+
+    Returns True when a stale lock was cleared.
+    """
+    lock = Path(profile_dir) / 'SingletonLock'
+    try:
+        target = os.readlink(lock)
+    except (OSError, ValueError):
+        # Absent, or not a symlink: nothing this function should act on.
+        return False
+
+    host, _, pid_text = target.rpartition('-')
+    if not host or not pid_text.isdigit():
+        return False
+    if host != socket.gethostname():
+        return False
+
+    pid = int(pid_text)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        pass          # owner is gone -- the lock is stale
+    except PermissionError:
+        return False  # exists under another uid, therefore alive
+    except OSError:
+        return False
+    else:
+        return False  # signal delivered: the owner is running
+
+    for name in ('SingletonLock', 'SingletonCookie', 'SingletonSocket'):
+        try:
+            (Path(profile_dir) / name).unlink()
+        except OSError:
+            pass
+    return True
 
 
 def stable_profile_index(profile: str, count: int) -> int:
@@ -799,6 +857,16 @@ class StealthBrowserSession:
             os.chmod(self.profile_dir, 0o700)
         except Exception:
             pass
+
+        # A crashed run leaves SingletonLock behind and every later launch against
+        # that profile then fails, so one crash locks out every process sharing it.
+        # Only a lock whose owner pid is provably dead on this host is removed.
+        if clear_stale_singleton_locks(self.profile_dir):
+            print(
+                f"⚠️  Cleared a stale singleton lock in {self.profile_dir} "
+                "(owning process was gone)",
+                file=sys.stderr,
+            )
 
         self._playwright = sync_playwright().start()
 

--- a/tests/browser-cli.test.ts
+++ b/tests/browser-cli.test.ts
@@ -941,3 +941,79 @@ describe.skipIf(!python)('screenshot cap is viewport-bound, not viewport-normali
     expect(source).not.toMatch(/_enforce_max_edge\(path,\s*1900\)/);
   });
 });
+
+// ── Stale singleton locks ──────────────────────────────────────────────────
+//
+// Chrome guards a user-data-dir with SingletonLock -> "<hostname>-<pid>". A clean
+// exit removes it; a crash does not. The leftover fails every LATER launch against
+// that profile, so one crash locks out every process sharing it. Measured
+// 2026-08-16: a crashed run left "Dmitris-MBP-25638" behind and each subsequent
+// run inherited the failure until the file was removed by hand.
+//
+// These assert on islink(), not exists(): the lock points at a name that is not a
+// real file, so exists() follows the dangling link and reports false for a lock
+// that is very much present. That is the same trap the implementation avoids by
+// reading the link rather than stat-ing it.
+describe('stale singleton lock cleanup', () => {
+  function lockState(dir: string, body: string[]) {
+    const r = runPython(['import os, socket', `d = ${JSON.stringify(dir)}`, ...body].join('\n'));
+    rmSync(dir, { recursive: true, force: true });
+    return r;
+  }
+
+  it('clears a lock whose owner pid is dead, and its companion files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prism-lock-dead-'));
+    const r = lockState(dir, [
+      // 4194303 is above the platform pid maximum, so it cannot be running.
+      'os.symlink(socket.gethostname() + "-4194303", os.path.join(d, "SingletonLock"))',
+      'open(os.path.join(d, "SingletonCookie"), "w").close()',
+      'open(os.path.join(d, "SingletonSocket"), "w").close()',
+      'cleared = browse.clear_stale_singleton_locks(d)',
+      'print(cleared, os.path.islink(os.path.join(d, "SingletonLock")),'
+        + ' os.path.exists(os.path.join(d, "SingletonCookie")),'
+        + ' os.path.exists(os.path.join(d, "SingletonSocket")))',
+    ]);
+    expect(r.status).toBe(0);
+    expect((r.stdout || '').trim()).toBe('True False False False');
+  });
+
+  it('leaves a LIVE lock alone — stealing it would corrupt a running session', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prism-lock-live-'));
+    const r = lockState(dir, [
+      'os.symlink(socket.gethostname() + "-" + str(os.getpid()), os.path.join(d, "SingletonLock"))',
+      'cleared = browse.clear_stale_singleton_locks(d)',
+      'print(cleared, os.path.islink(os.path.join(d, "SingletonLock")))',
+    ]);
+    expect(r.status).toBe(0);
+    expect((r.stdout || '').trim()).toBe('False True');
+  });
+
+  it('ignores a lock from a different host, where a pid proves nothing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prism-lock-host-'));
+    const r = lockState(dir, [
+      'os.symlink("some-other-machine-4194303", os.path.join(d, "SingletonLock"))',
+      'cleared = browse.clear_stale_singleton_locks(d)',
+      'print(cleared, os.path.islink(os.path.join(d, "SingletonLock")))',
+    ]);
+    expect(r.status).toBe(0);
+    expect((r.stdout || '').trim()).toBe('False True');
+  });
+
+  it('is a no-op on a profile with no lock at all', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'prism-lock-none-'));
+    const r = lockState(dir, ['print(browse.clear_stale_singleton_locks(d))']);
+    expect(r.status).toBe(0);
+    expect((r.stdout || '').trim()).toBe('False');
+  });
+
+  it('runs the cleanup BEFORE launching, not after', () => {
+    // Order is the whole point: clearing after launch_persistent_context would run
+    // only once the launch had already succeeded, i.e. never when it matters.
+    const source = readFileSync(scriptPath, 'utf8');
+    const cleanup = source.indexOf('clear_stale_singleton_locks(self.profile_dir)');
+    const launch = source.indexOf('launch_persistent_context(**launch_kwargs)');
+    expect(cleanup).toBeGreaterThan(-1);
+    expect(launch).toBeGreaterThan(-1);
+    expect(cleanup).toBeLessThan(launch);
+  });
+});

--- a/tests/browser-cli.test.ts
+++ b/tests/browser-cli.test.ts
@@ -954,14 +954,20 @@ describe.skipIf(!python)('screenshot cap is viewport-bound, not viewport-normali
 // real file, so exists() follows the dangling link and reports false for a lock
 // that is very much present. That is the same trap the implementation avoids by
 // reading the link rather than stat-ing it.
-describe('stale singleton lock cleanup', () => {
+describe.skipIf(!python)('stale singleton lock cleanup', () => {
+  // Creating a symlink on Windows needs elevated privileges, and Chrome there does
+  // not use a SingletonLock symlink at all -- the helper's readlink() raises OSError
+  // and returns immediately. So the symlink cases are POSIX-only; the no-lock and
+  // ordering contracts still run everywhere.
+  const symlinkUnavailable = process.platform === 'win32';
+
   function lockState(dir: string, body: string[]) {
     const r = runPython(['import os, socket', `d = ${JSON.stringify(dir)}`, ...body].join('\n'));
     rmSync(dir, { recursive: true, force: true });
     return r;
   }
 
-  it('clears a lock whose owner pid is dead, and its companion files', () => {
+  it.skipIf(symlinkUnavailable)('clears a lock whose owner pid is dead, and its companion files', () => {
     const dir = mkdtempSync(join(tmpdir(), 'prism-lock-dead-'));
     const r = lockState(dir, [
       // 4194303 is above the platform pid maximum, so it cannot be running.
@@ -977,7 +983,7 @@ describe('stale singleton lock cleanup', () => {
     expect((r.stdout || '').trim()).toBe('True False False False');
   });
 
-  it('leaves a LIVE lock alone — stealing it would corrupt a running session', () => {
+  it.skipIf(symlinkUnavailable)('leaves a LIVE lock alone — stealing it would corrupt a running session', () => {
     const dir = mkdtempSync(join(tmpdir(), 'prism-lock-live-'));
     const r = lockState(dir, [
       'os.symlink(socket.gethostname() + "-" + str(os.getpid()), os.path.join(d, "SingletonLock"))',
@@ -988,7 +994,7 @@ describe('stale singleton lock cleanup', () => {
     expect((r.stdout || '').trim()).toBe('False True');
   });
 
-  it('ignores a lock from a different host, where a pid proves nothing', () => {
+  it.skipIf(symlinkUnavailable)('ignores a lock from a different host, where a pid proves nothing', () => {
     const dir = mkdtempSync(join(tmpdir(), 'prism-lock-host-'));
     const r = lockState(dir, [
       'os.symlink("some-other-machine-4194303", os.path.join(d, "SingletonLock"))',


### PR DESCRIPTION
## The failure amplifier

Chrome guards a user-data-dir with `SingletonLock`, a symlink whose target is `<hostname>-<pid>`. A clean exit removes it; **a crash does not**. The leftover then fails every *later* launch against that profile — so one bad exit becomes a standing outage for every process sharing it.

Measured on a machine where several agent sessions share the `default` profile. One headed run died with:

```
BrowserType.launch_persistent_context: Target page, context or browser has been closed
kill EPERM → SIGTRAP
```

and left `SingletonLock -> Dmitris-MBP-25638`. Every subsequent run then failed for a reason that had nothing to do with the caller, and the only remedy was deleting the file by hand. The original crash affected one run; **the lock affected all of them**.

## The fix

`start()` clears the lock before launching, and only when the owner is provably gone:

- the hostname in the link must be this host — a pid from another machine says nothing about a local process
- `os.kill(pid, 0)` must raise `ProcessLookupError`

A **live** lock is left strictly alone: another session may be driving that profile, and stealing its lock would corrupt a running browser. `PermissionError` counts as alive, since the pid exists under another uid.

## Tests (5 added, 37 total passing)

- clears a dead-owner lock and its `SingletonCookie` / `SingletonSocket` companions
- **leaves a live lock alone** — the case that matters for concurrent sessions
- ignores a lock recorded by a different host
- no-op when there is no lock
- pins the **ordering**: cleanup must precede `launch_persistent_context`, since clearing afterwards would only ever run once the launch had already succeeded

They assert on `islink()`, not `exists()`. The lock points at a name that is not a real file, so `exists()` follows the dangling link and reports false for a lock that is plainly there — my first draft of these tests made exactly that mistake and passed for the wrong reason. It's the same trap the implementation avoids by reading the link rather than stat-ing it.

## Verification

Planted a stale lock, ran the patched CLI: it reported `Cleared a stale singleton lock` and reached `status: ok`. Neutering the cleanup fails the dead-pid test, so the suite cannot pass vacuously.

**Scope note:** this fixes the amplifier, not the underlying headed-launch crash on one specific bloated profile — that is still under investigation and is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)