### PR TITLE
feat(storage): wire listProjects + export to shipped portal actions; exports stop leaking tombstones

### DIFF
--- a/src/storage/interface.ts
+++ b/src/storage/interface.ts
@@ -469,6 +469,18 @@ export interface StorageBackend {
    */
   listProjects(): Promise<string[]>;
 
+  /**
+   * OPTIONAL: full ordered ledger for one project, for session_export_memory.
+   * Backends with a portal-mediated export (SynaluxStorage → action
+   * export_memory) implement this so paid thin-client installs export via
+   * the portal instead of falling through to an unconfigured direct-Supabase
+   * getLedgerEntries. Backends without it keep the local assembly path —
+   * deliberately NOT a getLedgerEntries override, because export_memory
+   * supports only project+pagination and would silently mis-serve the other
+   * getLedgerEntries call sites that pass arbitrary PostgREST filters.
+   */
+  exportLedger?(project: string): Promise<unknown[]>;
+
   // ─── v2.2.0 Health Check (fsck) ─────────────────────────────
 
   /**

--- a/src/storage/synalux.ts
+++ b/src/storage/synalux.ts
@@ -29,6 +29,8 @@
  *     - getHistory        → POST /api/v1/prism/memory  action=memory_history
  *     - patchLedger       → POST /api/v1/prism/memory  action=save_embedding
  *     - getEntriesMissingEmbeddings → POST /api/v1/prism/memory  action=list_missing_embeddings
+ *     - listProjects      → POST /api/v1/prism/memory  action=list_projects
+ *     - exportLedger      → POST /api/v1/prism/memory  action=export_memory (paginated)
  *
  *   Methods still falling through to SupabaseStorage (Phase 3 Tier B+):
  *   save_experience direct entrypoint, compactLedger, image ops,
@@ -546,6 +548,44 @@ export class SynaluxStorage extends SupabaseStorage {
     });
     const entries = Array.isArray(result.entries) ? result.entries : [];
     return entries as Array<{ id: string; summary: string; decisions?: string[]; project: string }>;
+  }
+
+  // ─── Project inventory + export ──────────────────────────────
+  // Both portal actions shipped in Phase 3 but the client was never
+  // wired: listProjects and the export path fell through to
+  // SupabaseStorage and threw "Supabase not configured" on every
+  // paid-tier install (2026-08-18 audit).
+
+  async listProjects(): Promise<string[]> {
+    const result = await this.portalPost("/api/v1/prism/memory", {
+      action: "list_projects",
+    });
+    const projects = Array.isArray(result.projects) ? result.projects : [];
+    return projects
+      .map((p: any) => (typeof p === "string" ? p : p?.project))
+      .filter((name: unknown): name is string => typeof name === "string" && name.length > 0);
+  }
+
+  async exportLedger(project: string): Promise<unknown[]> {
+    // action=export_memory is paginated (EXPORT_PAGE_SIZE=1000). Follow
+    // next_offset until has_more is false, capped at 10 pages to match the
+    // local path's 10k-row OOM guard.
+    const rows: unknown[] = [];
+    let offset = 0;
+    for (let page = 0; page < 10; page++) {
+      const result = await this.portalPost("/api/v1/prism/memory", {
+        action: "export_memory",
+        project,
+        offset,
+        limit: 1000,
+      });
+      const ledger = Array.isArray(result.ledger) ? result.ledger : [];
+      rows.push(...ledger);
+      const pageInfo = result.page as { has_more?: boolean; next_offset?: number | null } | undefined;
+      if (!pageInfo?.has_more || typeof pageInfo.next_offset !== "number") break;
+      offset = pageInfo.next_offset;
+    }
+    return rows;
   }
 
   // ─── Time Travel ─────────────────────────────────────────────

--- a/src/storage/synalux.ts
+++ b/src/storage/synalux.ts
@@ -560,8 +560,14 @@ export class SynaluxStorage extends SupabaseStorage {
     const result = await this.portalPost("/api/v1/prism/memory", {
       action: "list_projects",
     });
-    const projects = Array.isArray(result.projects) ? result.projects : [];
-    return projects
+    // Strict on drift: a 200 without a projects ARRAY is a contract change,
+    // not "no projects" — the portal returns projects:[] for genuinely none.
+    // Coercing drift to [] would make callers report empty inventories while
+    // claiming success. (R1 adversarial review 2026-08-18.)
+    if (!Array.isArray(result.projects)) {
+      throw new Error("[SynaluxStorage] list_projects: portal response missing projects[] — contract drift");
+    }
+    return result.projects
       .map((p: any) => (typeof p === "string" ? p : p?.project))
       .filter((name: unknown): name is string => typeof name === "string" && name.length > 0);
   }
@@ -570,6 +576,11 @@ export class SynaluxStorage extends SupabaseStorage {
     // action=export_memory is paginated (EXPORT_PAGE_SIZE=1000). Follow
     // next_offset until has_more is false, capped at 10 pages to match the
     // local path's 10k-row OOM guard.
+    //
+    // Strict on drift (R1 adversarial review 2026-08-18): this feeds a
+    // BACKUP. A 200 missing ledger[] or page{} must throw, not degrade —
+    // coercing either would write an empty or silently-truncated export
+    // file that reports ✅ success, which is worse than any error.
     const rows: unknown[] = [];
     let offset = 0;
     for (let page = 0; page < 10; page++) {
@@ -579,10 +590,15 @@ export class SynaluxStorage extends SupabaseStorage {
         offset,
         limit: 1000,
       });
-      const ledger = Array.isArray(result.ledger) ? result.ledger : [];
-      rows.push(...ledger);
+      if (!Array.isArray(result.ledger)) {
+        throw new Error("[SynaluxStorage] export_memory: portal response missing ledger[] — contract drift");
+      }
       const pageInfo = result.page as { has_more?: boolean; next_offset?: number | null } | undefined;
-      if (!pageInfo?.has_more || typeof pageInfo.next_offset !== "number") break;
+      if (typeof pageInfo?.has_more !== "boolean") {
+        throw new Error("[SynaluxStorage] export_memory: portal response missing page.has_more — refusing a possibly-truncated export");
+      }
+      rows.push(...result.ledger);
+      if (!pageInfo.has_more || typeof pageInfo.next_offset !== "number") break;
       offset = pageInfo.next_offset;
     }
     return rows;

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -3086,6 +3086,13 @@ export async function sessionExportMemoryHandler(args: unknown) {
         ? await storage.exportLedger(project)
         : await storage.getLedgerEntries({
             project: `eq.${project}`,
+            // R1 adversarial review 2026-08-18: without this filter the
+            // direct/local paths exported TOMBSTONED rows — content the user
+            // had asked session_forget_memory to erase shipped in every
+            // backup (GDPR Art. 17 leak; the portal export always excluded
+            // them, so the two paths also disagreed). Both PostgREST and the
+            // sqlite filter parser support is.null.
+            deleted_at: "is.null",
             order: "created_at.asc",
             limit: "10000",
           })) as Array<{

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -3078,12 +3078,17 @@ export async function sessionExportMemoryHandler(args: unknown) {
         [key: string]: unknown;
       } | null;
 
-      // Fetch full ledger (all non-deleted entries, capped at 10k as OOM guard)
-      const ledger = await storage.getLedgerEntries({
-        project: `eq.${project}`,
-        order: "created_at.asc",
-        limit: "10000",
-      }) as Array<{
+      // Fetch full ledger (all non-deleted entries, capped at 10k as OOM guard).
+      // Portal-backed installs export via action=export_memory (exportLedger);
+      // local/direct backends keep the getLedgerEntries assembly. Without this
+      // branch, paid thin-client installs threw "Supabase not configured" here.
+      const ledger = (typeof storage.exportLedger === "function"
+        ? await storage.exportLedger(project)
+        : await storage.getLedgerEntries({
+            project: `eq.${project}`,
+            order: "created_at.asc",
+            limit: "10000",
+          })) as Array<{
         id?: string;
         created_at?: string;
         event_type?: string;

--- a/tests/storage/synalux-projects-export.test.ts
+++ b/tests/storage/synalux-projects-export.test.ts
@@ -92,6 +92,17 @@ describe("SynaluxStorage — listProjects (action=list_projects)", () => {
     const s = new SynaluxStorage();
     expect(await s.listProjects()).toEqual(["good", "bare-string"]);
   });
+
+  it("throws on a 200 missing projects[] — drift is not an empty inventory", async () => {
+    // The portal returns projects:[] for genuinely none; a missing field is
+    // a contract change and must not read as "no projects".
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, { status: "success", items: [] }));
+
+    const s = new SynaluxStorage();
+    await expect(s.listProjects()).rejects.toThrow(/contract drift/);
+  });
 });
 
 describe("SynaluxStorage — exportLedger (action=export_memory)", () => {
@@ -143,6 +154,29 @@ describe("SynaluxStorage — exportLedger (action=export_memory)", () => {
     expect(rows).toEqual([{ id: "1" }, { id: "2" }]);
     const second = JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string);
     expect(second.offset).toBe(1000);
+  });
+
+  it("throws on a 200 missing ledger[] — drift must not become an empty backup", async () => {
+    // R1 adversarial review: coercing a renamed/missing field to [] writes
+    // an empty export file that reports ✅ success. For a backup path, that
+    // is strictly worse than an error.
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, { status: "success", rows: [{ id: "1" }] }));
+
+    const s = new SynaluxStorage();
+    await expect(s.exportLedger("demo")).rejects.toThrow(/contract drift/);
+  });
+
+  it("throws on a 200 missing page info — refuses a possibly-truncated export", async () => {
+    // Without page.has_more the client cannot know whether more rows exist;
+    // breaking out silently would ship a partial backup marked complete.
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, { status: "success", ledger: [{ id: "1" }] }));
+
+    const s = new SynaluxStorage();
+    await expect(s.exportLedger("demo")).rejects.toThrow(/possibly-truncated/);
   });
 
   it("caps pagination at 10 pages — a lying has_more cannot loop forever", async () => {

--- a/tests/storage/synalux-projects-export.test.ts
+++ b/tests/storage/synalux-projects-export.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests — SynaluxStorage listProjects (action=list_projects) and
+ * exportLedger (action=export_memory, paginated).
+ *
+ * Both portal actions shipped in Phase 3 but the client overrides were
+ * never written, so on paid thin-client installs (no SUPABASE_URL) both
+ * paths fell through to SupabaseStorage and threw "Supabase not
+ * configured" — session_export_memory and the 3 listProjects call sites
+ * were dead on exactly the tier that pays for them (2026-08-18 audit).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const PORTAL_URL = "https://portal.test";
+const REFRESH_TOKEN = "synalux_sk_abcdef1234567890";
+
+vi.mock("../../src/storage/supabase.js", () => ({
+  SupabaseStorage: class {
+    async initialize() { /* no-op */ }
+    async close() { /* no-op */ }
+    // The fall-through failure this migration removes. If an override is
+    // deleted, tests fail HERE with the real production symptom.
+    async listProjects() { throw new Error("Supabase not configured (SUPABASE_URL / SUPABASE_KEY missing)"); }
+    async getLedgerEntries() { throw new Error("Supabase not configured (SUPABASE_URL / SUPABASE_KEY missing)"); }
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  sanitizeForLog: vi.fn((s: string) => s),
+  debugLog: vi.fn(),
+}));
+
+async function importFreshSynaluxStorage() {
+  vi.resetModules();
+  process.env.PRISM_SYNALUX_BASE_URL = PORTAL_URL;
+  process.env.PRISM_SYNALUX_API_KEY = REFRESH_TOKEN;
+  const mod = await import("../../src/storage/synalux.js");
+  return mod.SynaluxStorage;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function freshJwtResp() {
+  return jsonResponse(200, { status: "success", jwt: "jwt-1", expires_in: 900 });
+}
+
+describe("SynaluxStorage — listProjects (action=list_projects)", () => {
+  const fetchMock = vi.fn();
+  let SynaluxStorage: typeof import("../../src/storage/synalux.js")["SynaluxStorage"];
+
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    SynaluxStorage = await importFreshSynaluxStorage();
+  });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("returns project names from the portal inventory payload", async () => {
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, {
+        status: "success",
+        action: "list_projects",
+        count: 2,
+        projects: [
+          { project: "alpha", ledger: 10, handoffs: 1, history: 3 },
+          { project: "beta", ledger: 4, handoffs: 1, history: 0 },
+        ],
+      }));
+
+    const s = new SynaluxStorage();
+    const out = await s.listProjects();
+
+    expect(out).toEqual(["alpha", "beta"]);
+    const body = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(body).toEqual({ action: "list_projects" });
+  });
+
+  it("tolerates malformed rows rather than returning undefined names", async () => {
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, {
+        status: "success",
+        projects: [{ project: "good" }, { ledger: 5 }, null, "bare-string", { project: "" }],
+      }));
+
+    const s = new SynaluxStorage();
+    expect(await s.listProjects()).toEqual(["good", "bare-string"]);
+  });
+});
+
+describe("SynaluxStorage — exportLedger (action=export_memory)", () => {
+  const fetchMock = vi.fn();
+  let SynaluxStorage: typeof import("../../src/storage/synalux.js")["SynaluxStorage"];
+
+  beforeEach(async () => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    SynaluxStorage = await importFreshSynaluxStorage();
+  });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("collects a single page and stops when has_more is false", async () => {
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, {
+        status: "success",
+        action: "export_memory",
+        ledger: [{ id: "1", summary: "a" }, { id: "2", summary: "b" }],
+        page: { offset: 0, limit: 1000, returned: 2, total: 2, has_more: false, next_offset: null },
+      }));
+
+    const s = new SynaluxStorage();
+    const rows = await s.exportLedger("demo");
+
+    expect(rows).toEqual([{ id: "1", summary: "a" }, { id: "2", summary: "b" }]);
+    const body = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    expect(body).toEqual({ action: "export_memory", project: "demo", offset: 0, limit: 1000 });
+  });
+
+  it("follows next_offset across pages in order", async () => {
+    fetchMock
+      .mockResolvedValueOnce(freshJwtResp())
+      .mockResolvedValueOnce(jsonResponse(200, {
+        status: "success",
+        ledger: [{ id: "1" }],
+        page: { has_more: true, next_offset: 1000 },
+      }))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        status: "success",
+        ledger: [{ id: "2" }],
+        page: { has_more: false, next_offset: null },
+      }));
+
+    const s = new SynaluxStorage();
+    const rows = await s.exportLedger("demo");
+
+    expect(rows).toEqual([{ id: "1" }, { id: "2" }]);
+    const second = JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string);
+    expect(second.offset).toBe(1000);
+  });
+
+  it("caps pagination at 10 pages — a lying has_more cannot loop forever", async () => {
+    fetchMock.mockResolvedValueOnce(freshJwtResp());
+    for (let i = 0; i < 20; i++) {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        status: "success",
+        ledger: [{ id: String(i) }],
+        page: { has_more: true, next_offset: (i + 1) * 1000 },
+      }));
+    }
+
+    const s = new SynaluxStorage();
+    const rows = await s.exportLedger("demo");
+
+    expect(rows).toHaveLength(10);
+    // 1 JWT call + 10 export pages, then the cap stops it.
+    expect(fetchMock.mock.calls.length).toBe(11);
+  });
+});

--- a/tests/tools/sessionExportMemory.test.ts
+++ b/tests/tools/sessionExportMemory.test.ts
@@ -767,13 +767,34 @@ describe("sessionExportMemoryHandler — session_export_memory", () => {
      * - listProjects() — not called when a specific project is given
      */
 
-    it("getLedgerEntries called with PostgREST-style filter, order, and limit", async () => {
+    it("getLedgerEntries excludes tombstones — forgotten content must not ship in a backup", async () => {
+      // R1 adversarial review 2026-08-18: without deleted_at=is.null the
+      // direct/local export included rows the user had asked
+      // session_forget_memory to erase (GDPR Art. 17), and disagreed with
+      // the portal export path, which always excluded them.
       await sessionExportMemoryHandler({ project: "test-project", format: "json", output_dir: tempDir });
       expect(storage.getLedgerEntries).toHaveBeenCalledWith({
         project: "eq.test-project",
+        deleted_at: "is.null",
         order: "created_at.asc",
         limit: "10000",
       });
+    });
+
+    it("prefers a portal-backed exportLedger when the backend provides one", async () => {
+      // Paid thin-client installs have no SUPABASE_URL; getLedgerEntries
+      // throws there. When the backend exposes exportLedger (SynaluxStorage
+      // → action=export_memory), the handler must use it and must NOT touch
+      // getLedgerEntries.
+      (storage as any).exportLedger = vi.fn().mockResolvedValue([FIXTURE_LEDGER_ENTRY]);
+      try {
+        const result = await sessionExportMemoryHandler({ project: "test-project", format: "json", output_dir: tempDir });
+        expect(result.isError).toBeFalsy();
+        expect((storage as any).exportLedger).toHaveBeenCalledWith("test-project");
+        expect(storage.getLedgerEntries).not.toHaveBeenCalled();
+      } finally {
+        delete (storage as any).exportLedger;
+      }
     });
 
     it("loadContext called with positional (project, 'deep', PRISM_USER_ID)", async () => {


### PR DESCRIPTION
Two Phase 3 portal endpoints shipped with no client ever wired — `SynaluxStorage` inherited both paths from direct-Supabase, which throws `Supabase not configured` on thin-client installs. `session_export_memory` and all 3 `listProjects` call sites were dead on exactly the tier that pays for them.

## Wiring
- `listProjects` → `POST /api/v1/prism/memory` `action=list_projects`
- `exportLedger` (new optional interface method) → `action=export_memory`, paginated (1000/page, 10-page cap matching the local 10k OOM guard); `session_export_memory` prefers it when the backend provides it. Deliberately **not** a `getLedgerEntries` override — that action supports only project+pagination and would silently mis-serve the 16 other call sites with arbitrary filters.

## Adversarial review (3 rounds to convergence), fixes included
1. **HIGH (pre-existing, found by parity diff):** direct/local exports included **tombstoned rows** — content the user asked `session_forget_memory` to erase shipped in every backup, and disagreed with the portal path which always excluded them. Fixed with `deleted_at=is.null`; sqlite filter parser supports it, allowlists the column, and the startup migration adds it for upgraders.
2. **MEDIUM:** 200 missing `ledger[]` coerced to `[]` → an **empty export file reporting success**. Now throws contract-drift.
3. **MEDIUM:** 200 missing `page.has_more` → silent one-page truncation marked complete. Now refuses.
4. **LOW:** `listProjects` drift coerced to empty inventory. Now throws; `ListResources` catch verified graceful (`resources: []`).

All three drift guards mutation-tested — reverting each to coercion fails exactly its test. The old params-pin test went red against fix 1 before being updated. Tests mock the parent class to throw the real production symptom, so deleting an override fails with the actual failure mode.

Portal companion (private repo, deployed first): `list_projects` made quota-exempt — this wiring turns host-driven MCP `ListResources` refreshes into daily-quota drain otherwise; same rationale as the `health_check` exemption, read-bucket rate limit still bounds it.

Full suite: 179 files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)