### PR TITLE
feat(cli): converge models in prism connect — the missing half of self-update

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -267,7 +267,8 @@ program
   .option('--dry-run', 'Preview configuration changes without writing files')
   .option('--refresh', 'Refresh only entries previously created by Prism; custom entries stay untouched')
   .option('--no-self-update', 'Skip the npm self-update check; configure with the currently installed version')
-  .action(async (options: { host?: string; all?: boolean; dryRun?: boolean; refresh?: boolean; selfUpdate?: boolean }) => {
+  .option('--no-models', 'Skip model convergence; keep whatever model versions are installed')
+  .action(async (options: { host?: string; all?: boolean; dryRun?: boolean; refresh?: boolean; selfUpdate?: boolean; models?: boolean }) => {
     try {
       // ── Converge the PACKAGE first, then the configs ──────────────
       // connect is the one command the operator runs to make a machine
@@ -489,6 +490,17 @@ program
       }
       if (!summary.usedApiKey) {
         console.log('PRISM_SYNALUX_API_KEY is not set; no Synalux subscription key was copied into new registrations.');
+      }
+      // ── Converge the MODELS last ────────────────────────────────
+      // selfUpdate above is the package half of convergence; without this
+      // half a machine kept vision-less models for four days after the
+      // registry carried the fix (2026-08-18), and `ollama cp` aliases are
+      // snapshots that silently detach from their source on every re-pull.
+      // Failures here never fail connect — runOllamaConverge reports and
+      // returns.
+      if (options.models !== false) {
+        const { runOllamaConverge } = await import('./modelConvergeRunner.js');
+        await runOllamaConverge({ dryRun: options.dryRun === true });
       }
     } catch (err) {
       console.error(`Connect failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -1114,6 +1126,20 @@ scmCmd
       console.error(`DORA failed: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
     }
+  });
+
+// ─── prism update-models ──────────────────────────────────────
+// Standalone model convergence: pull each installed prism-coder tier from
+// the registry and repair its local alias. connect runs this automatically;
+// this command is for updating models without touching host configuration.
+program
+  .command('update-models')
+  .description('Pull installed prism-coder models from the registry and repair stale local aliases')
+  .option('--dry-run', 'Print what would be pulled/re-aliased without executing')
+  .action(async (options: { dryRun?: boolean }) => {
+    const { runOllamaConverge } = await import('./modelConvergeRunner.js');
+    const outcomes = await runOllamaConverge({ dryRun: options.dryRun === true });
+    if (outcomes.every(o => o.action === 'failed')) process.exitCode = 1;
   });
 
 // ─── prism register-models ────────────────────────────────────

--- a/src/modelConvergeRunner.ts
+++ b/src/modelConvergeRunner.ts
@@ -1,0 +1,48 @@
+/**
+ * Production wiring for model convergence — real Ollama, real registry.
+ *
+ * Kept out of cli.ts so the pure logic (utils/modelConverge.ts) stays
+ * testable with injected deps, and out of utils/ because this half owns
+ * process spawning. `ollama pull` runs with inherited stdio deliberately:
+ * a multi-GB download with no progress bar reads as a hang, and ollama's
+ * own progress output is better than anything we would reimplement.
+ */
+import { spawn } from "node:child_process";
+import { convergeModels, type TierOutcome } from "./utils/modelConverge.js";
+
+const OLLAMA_URL = process.env.PRISM_LOCAL_LLM_URL || "http://localhost:11434";
+
+function runOllama(args: string[], inheritStdio: boolean): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = spawn("ollama", args, {
+            stdio: inheritStdio ? "inherit" : "ignore",
+        });
+        child.on("error", (err) => reject(new Error(`ollama ${args[0]}: ${err.message}`)));
+        child.on("close", (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`ollama ${args.join(" ")} exited ${code}`));
+        });
+    });
+}
+
+export async function runOllamaConverge(opts: { dryRun?: boolean } = {}): Promise<TierOutcome[]> {
+    console.log("\nConverging local models against the registry…");
+    const outcomes = await convergeModels({
+        listTags: async () => {
+            const res = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(5_000) });
+            if (!res.ok) throw new Error(`Ollama /api/tags HTTP ${res.status}`);
+            const data = (await res.json()) as { models?: Array<{ name: string; digest: string }> };
+            return (data.models ?? []).map((m) => ({ name: m.name, digest: m.digest }));
+        },
+        pull: (ref) => runOllama(["pull", ref], true),
+        copy: (from, to) => runOllama(["cp", from, to], false),
+        log: (line) => console.log(`  ${line}`),
+        dryRun: opts.dryRun,
+    });
+
+    const failed = outcomes.filter((o) => o.action === "failed" && o.detail !== "ollama_unreachable");
+    if (failed.length > 0) {
+        console.log(`  ⚠ ${failed.length} tier(s) did not converge — re-run \`prism update-models\` when the network allows`);
+    }
+    return outcomes;
+}

--- a/src/utils/modelConverge.ts
+++ b/src/utils/modelConverge.ts
@@ -1,0 +1,132 @@
+/**
+ * Model convergence for `prism connect` — the missing half of self-update.
+ *
+ * selfUpdate.ts converges the PACKAGE; nothing converged the MODELS. The gap
+ * was measured on 2026-08-18: the vision-restored artifacts had been on the
+ * Ollama registry for four days while a laptop that pulled earlier kept
+ * refusing image requests (layer1_classifier_no_vision) — and on the machine
+ * where this was written, the `prism-coder:2b` alias pointed at different
+ * bytes than `dcostenco/prism-coder:2b`, because `ollama cp` makes a
+ * SNAPSHOT: a re-pull updates the source name and silently leaves every
+ * alias behind.
+ *
+ * Design decisions, in order of importance:
+ *
+ * 1. DELEGATE freshness to `ollama pull`. The registry serves no
+ *    docker-content-digest header and its manifest body hash is not the
+ *    digest ollama reports locally, so a client-side digest comparison
+ *    would reimplement (and drift from) ollama's own logic. `ollama pull`
+ *    of an up-to-date tag is a manifest check that downloads nothing.
+ *
+ * 2. REPAIR the alias after every pull. `prism-coder:<t>` must equal
+ *    `dcostenco/prism-coder:<t>` byte-for-byte; when digests differ, re-cp.
+ *    This is the trap register-models cannot fix on its own — it only
+ *    aliases tags that are MISSING, not tags that are stale.
+ *
+ * 3. Converge only tiers the machine already has (either the alias or the
+ *    namespaced source). Convergence updates what you chose to install; it
+ *    never decides that a 16 GB model belongs on your laptop.
+ *
+ * 4. Models must never break connect. Ollama down, registry unreachable,
+ *    one tier failing — report and continue. A machine with stale models
+ *    and fresh config beats a machine with neither.
+ */
+
+export const MODEL_NAMESPACE = "dcostenco/prism-coder";
+export const LOCAL_PREFIX = "prism-coder";
+export const CONVERGE_TIERS = ["2b", "4b", "9b", "27b"] as const;
+
+export interface TagInfo {
+    name: string;
+    digest: string;
+}
+
+export interface ModelConvergeDeps {
+    /** GET <ollamaUrl>/api/tags → installed models with digests. Throws when unreachable. */
+    listTags: () => Promise<TagInfo[]>;
+    /** `ollama pull <ref>` — throws on failure. */
+    pull: (ref: string) => Promise<void>;
+    /** `ollama cp <from> <to>` — throws on failure. */
+    copy: (from: string, to: string) => Promise<void>;
+    log: (line: string) => void;
+    dryRun?: boolean;
+}
+
+export interface TierOutcome {
+    tier: string;
+    action: "pulled_and_aliased" | "aliased_only" | "up_to_date" | "skipped_not_installed" | "failed";
+    detail?: string;
+}
+
+export async function convergeModels(deps: ModelConvergeDeps): Promise<TierOutcome[]> {
+    let tags: TagInfo[];
+    try {
+        tags = await deps.listTags();
+    } catch (err) {
+        deps.log(`− model convergence skipped: Ollama unreachable (${err instanceof Error ? err.message : String(err)})`);
+        return CONVERGE_TIERS.map((tier) => ({ tier, action: "failed" as const, detail: "ollama_unreachable" }));
+    }
+
+    const byName = new Map(tags.map((t) => [t.name, t]));
+    const outcomes: TierOutcome[] = [];
+
+    for (const tier of CONVERGE_TIERS) {
+        const source = `${MODEL_NAMESPACE}:${tier}`;
+        const alias = `${LOCAL_PREFIX}:${tier}`;
+        const hadSource = byName.has(source);
+        const hadAlias = byName.has(alias);
+
+        if (!hadSource && !hadAlias) {
+            outcomes.push({ tier, action: "skipped_not_installed" });
+            continue;
+        }
+
+        if (deps.dryRun) {
+            deps.log(`• would pull ${source} and repair the ${alias} alias if stale`);
+            outcomes.push({ tier, action: "up_to_date", detail: "dry_run" });
+            continue;
+        }
+
+        try {
+            const digestBefore = byName.get(source)?.digest;
+            await deps.pull(source);
+
+            // Re-list AFTER the pull: both the freshness answer and the alias
+            // comparison must come from post-pull state, or a pull that
+            // changed bytes looks identical to one that did nothing.
+            const after = await deps.listTags();
+            const afterByName = new Map(after.map((t) => [t.name, t]));
+            const sourceNow = afterByName.get(source);
+            const aliasNow = afterByName.get(alias);
+
+            if (!sourceNow) {
+                outcomes.push({ tier, action: "failed", detail: "source_missing_after_pull" });
+                deps.log(`⚠ ${source}: pull reported success but the tag is not installed`);
+                continue;
+            }
+
+            const pulledNewBytes = digestBefore !== undefined && digestBefore !== sourceNow.digest;
+            const aliasStale = !aliasNow || aliasNow.digest !== sourceNow.digest;
+
+            if (aliasStale) {
+                await deps.copy(source, alias);
+                const action = pulledNewBytes || !hadSource ? "pulled_and_aliased" : "aliased_only";
+                outcomes.push({ tier, action });
+                deps.log(`✓ ${alias} ${aliasNow ? "re-aliased (was a stale snapshot)" : "aliased"} → ${sourceNow.digest.slice(0, 12)}`);
+            } else if (pulledNewBytes) {
+                // Alias digest already matches the fresh source — cp raced us
+                // or the user re-aliased by hand; either way converged.
+                outcomes.push({ tier, action: "pulled_and_aliased" });
+                deps.log(`✓ ${source} updated; ${alias} already matches`);
+            } else {
+                outcomes.push({ tier, action: "up_to_date" });
+                deps.log(`= ${alias} up to date (${sourceNow.digest.slice(0, 12)})`);
+            }
+        } catch (err) {
+            outcomes.push({ tier, action: "failed", detail: err instanceof Error ? err.message : String(err) });
+            deps.log(`⚠ ${source}: ${err instanceof Error ? err.message : String(err)} — continuing with the other tiers`);
+        }
+    }
+
+    return outcomes;
+}

--- a/tests/utils/modelConverge.test.ts
+++ b/tests/utils/modelConverge.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests — model convergence (the missing half of self-update).
+ *
+ * The failure modes these pin were all OBSERVED on 2026-08-18:
+ * - a laptop kept vision-less models for four days after the registry was
+ *   fixed (no convergence existed at all)
+ * - prism-coder:2b on the authoring machine was a stale `ollama cp`
+ *   snapshot pointing at different bytes than its source
+ * - registry digest comparison is not implementable client-side (no
+ *   docker-content-digest header; manifest body hash ≠ ollama's digest),
+ *   which is why freshness is delegated to `ollama pull`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { convergeModels, type TagInfo } from "../../src/utils/modelConverge.js";
+
+function harness(tagsSequence: TagInfo[][], opts: { pullFails?: string[] } = {}) {
+    let call = 0;
+    const pulls: string[] = [];
+    const copies: Array<[string, string]> = [];
+    const logs: string[] = [];
+    const deps = {
+        listTags: vi.fn(async () => tagsSequence[Math.min(call++, tagsSequence.length - 1)]),
+        pull: vi.fn(async (ref: string) => {
+            pulls.push(ref);
+            if (opts.pullFails?.includes(ref)) throw new Error(`pull failed: ${ref}`);
+        }),
+        copy: vi.fn(async (from: string, to: string) => { copies.push([from, to]); }),
+        log: (l: string) => logs.push(l),
+    };
+    return { deps, pulls, copies, logs };
+}
+
+const T = (name: string, digest: string): TagInfo => ({ name, digest });
+
+describe("convergeModels", () => {
+    it("repairs a stale alias — the ollama cp snapshot trap, observed live", async () => {
+        // 2b alias points at OLD bytes; source is current. Post-pull state
+        // unchanged (pull was a no-op) — the alias must still be re-cp'd.
+        const state = [
+            T("dcostenco/prism-coder:2b", "new222"),
+            T("prism-coder:2b", "old111"),
+        ];
+        const { deps, copies } = harness([state, state]);
+        const out = await convergeModels(deps);
+
+        expect(copies).toContainEqual(["dcostenco/prism-coder:2b", "prism-coder:2b"]);
+        expect(out.find(o => o.tier === "2b")?.action).toBe("aliased_only");
+    });
+
+    it("pull that changes bytes re-aliases and reports pulled_and_aliased", async () => {
+        const before = [T("dcostenco/prism-coder:4b", "aaa"), T("prism-coder:4b", "aaa")];
+        const after = [T("dcostenco/prism-coder:4b", "bbb"), T("prism-coder:4b", "aaa")];
+        const { deps, copies } = harness([before, after]);
+        const out = await convergeModels(deps);
+
+        expect(copies).toContainEqual(["dcostenco/prism-coder:4b", "prism-coder:4b"]);
+        expect(out.find(o => o.tier === "4b")?.action).toBe("pulled_and_aliased");
+    });
+
+    it("up-to-date tier does nothing but a pull check", async () => {
+        const state = [T("dcostenco/prism-coder:9b", "same"), T("prism-coder:9b", "same")];
+        const { deps, pulls, copies } = harness([state, state]);
+        const out = await convergeModels(deps);
+
+        expect(pulls).toContain("dcostenco/prism-coder:9b");
+        expect(copies).toHaveLength(0);
+        expect(out.find(o => o.tier === "9b")?.action).toBe("up_to_date");
+    });
+
+    it("never pulls tiers the machine did not install", async () => {
+        const state = [T("dcostenco/prism-coder:4b", "x"), T("prism-coder:4b", "x")];
+        const { deps, pulls } = harness([state, state]);
+        const out = await convergeModels(deps);
+
+        expect(pulls).toEqual(["dcostenco/prism-coder:4b"]);
+        expect(out.find(o => o.tier === "27b")?.action).toBe("skipped_not_installed");
+        expect(out.find(o => o.tier === "2b")?.action).toBe("skipped_not_installed");
+    });
+
+    it("an alias with no source still converges — pull creates the source, then aliases", async () => {
+        // A machine that only ever had the local alias (pre-namespace installs).
+        const before = [T("prism-coder:4b", "old")];
+        const after = [T("prism-coder:4b", "old"), T("dcostenco/prism-coder:4b", "fresh")];
+        const { deps, copies } = harness([before, after]);
+        const out = await convergeModels(deps);
+
+        expect(copies).toContainEqual(["dcostenco/prism-coder:4b", "prism-coder:4b"]);
+        expect(out.find(o => o.tier === "4b")?.action).toBe("pulled_and_aliased");
+    });
+
+    it("one tier failing does not stop the others", async () => {
+        const state = [
+            T("dcostenco/prism-coder:2b", "a"), T("prism-coder:2b", "a"),
+            T("dcostenco/prism-coder:4b", "b"), T("prism-coder:4b", "b"),
+        ];
+        const { deps, pulls } = harness([state, state, state], { pullFails: ["dcostenco/prism-coder:2b"] });
+        const out = await convergeModels(deps);
+
+        expect(out.find(o => o.tier === "2b")?.action).toBe("failed");
+        expect(pulls).toContain("dcostenco/prism-coder:4b");
+        expect(out.find(o => o.tier === "4b")?.action).toBe("up_to_date");
+    });
+
+    it("Ollama unreachable skips convergence without throwing — models never break connect", async () => {
+        const deps = {
+            listTags: vi.fn(async () => { throw new Error("ECONNREFUSED"); }),
+            pull: vi.fn(), copy: vi.fn(), log: vi.fn(),
+        };
+        const out = await convergeModels(deps);
+        expect(out.every(o => o.action === "failed")).toBe(true);
+        expect(deps.pull).not.toHaveBeenCalled();
+    });
+
+    it("dry run reports intent and executes nothing", async () => {
+        const state = [T("dcostenco/prism-coder:4b", "x"), T("prism-coder:4b", "STALE")];
+        const { deps, pulls, copies, logs } = harness([state]);
+        (deps as any).dryRun = true;
+        await convergeModels({ ...deps, dryRun: true });
+
+        expect(pulls).toHaveLength(0);
+        expect(copies).toHaveLength(0);
+        expect(logs.some(l => l.includes("would pull"))).toBe(true);
+    });
+});


### PR DESCRIPTION
`prism connect` self-updates the npm package but nothing converged the models. Measured cost of that gap: a machine kept vision-less models for four days after the registry carried the fix, and on the authoring machine the `prism-coder:2b` alias pointed at different bytes than `dcostenco/prism-coder:2b` — `ollama cp` aliases are snapshots that silently detach from their source on every re-pull.

## Design
- **Freshness is delegated to `ollama pull`** (idempotent, cheap when current). The registry serves no `docker-content-digest` header and its manifest body hash is not ollama's local digest, so client-side digest comparison would reimplement — and drift from — ollama's own logic.
- **The alias is repaired after every pull**: compared to its source post-pull and re-`cp`'d when stale. This is the repair `register-models` cannot make — it only aliases *missing* tags, not stale ones.
- **Only installed tiers converge.** Convergence updates what you chose to install; it never decides a 16 GB model belongs on your laptop.
- **Model failures never fail connect** — report and continue; ollama unreachable skips gracefully.

Surfaces: automatic in `prism connect` (`--no-models` opts out, dry-run supported) and standalone as `prism update-models`.

## Evidence
Proven live before commit: dry-run listed all four tiers; the real run pulled a newer 27b (16 GB), refreshed 4b/9b, and repaired a genuinely stale 2b alias — post-state all four aliases byte-identical to their sources, vision capability intact on 2b/4b/9b, and a live image inference through the running server answered correctly on the freshly pulled blobs. 8 unit tests pin the snapshot-trap repair, changed-bytes re-alias, not-installed skip, per-tier failure isolation, unreachable-ollama skip, and dry-run inertness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)