### PR TITLE
fix(cli): pin the ollama CLI to the daemon tags are read from; announce pulls before they start

### DIFF
--- a/src/modelConvergeRunner.ts
+++ b/src/modelConvergeRunner.ts
@@ -6,16 +6,42 @@
  * process spawning. `ollama pull` runs with inherited stdio deliberately:
  * a multi-GB download with no progress bar reads as a hang, and ollama's
  * own progress output is better than anything we would reimplement.
+ *
+ * Adversarial review 2026-08-18 (pre-20.14.0), two findings fixed here:
+ *
+ * 1. SPLIT-BRAIN DAEMON TARGETING: listTags read /api/tags from
+ *    PRISM_LOCAL_LLM_URL while the spawned `ollama` CLI targeted whatever
+ *    OLLAMA_HOST the user's shell had (default localhost). On a machine
+ *    with a remote Ollama, convergence read tags from one daemon and
+ *    pulled/re-aliased against another. The spawn env now pins OLLAMA_HOST
+ *    to the SAME url the tags came from — one daemon, one truth.
+ *
+ * 2. SILENT MULTI-GB DOWNLOADS: connect gave no warning before pulling.
+ *    Measured the day this shipped: the registry 27b had just changed
+ *    bytes, so every 27b holder's first converge pulls ~16 GB. The plan
+ *    is now announced up front, with the --no-models escape hatch named,
+ *    before any network transfer starts.
  */
 import { spawn } from "node:child_process";
-import { convergeModels, type TierOutcome } from "./utils/modelConverge.js";
+import { convergeModels, type TierOutcome, MODEL_NAMESPACE, LOCAL_PREFIX, CONVERGE_TIERS } from "./utils/modelConverge.js";
 
 const OLLAMA_URL = process.env.PRISM_LOCAL_LLM_URL || "http://localhost:11434";
+
+/**
+ * Env for spawned `ollama` processes. OLLAMA_HOST is pinned to the same
+ * daemon /api/tags was read from — never the shell's ambient value — so
+ * list, pull, and cp can never disagree about which Ollama they act on.
+ * Exported for tests.
+ */
+export function convergeEnv(base: NodeJS.ProcessEnv, ollamaUrl: string = OLLAMA_URL): NodeJS.ProcessEnv {
+    return { ...base, OLLAMA_HOST: ollamaUrl };
+}
 
 function runOllama(args: string[], inheritStdio: boolean): Promise<void> {
     return new Promise((resolve, reject) => {
         const child = spawn("ollama", args, {
             stdio: inheritStdio ? "inherit" : "ignore",
+            env: convergeEnv(process.env),
         });
         child.on("error", (err) => reject(new Error(`ollama ${args[0]}: ${err.message}`)));
         child.on("close", (code) => {
@@ -26,7 +52,34 @@ function runOllama(args: string[], inheritStdio: boolean): Promise<void> {
 }
 
 export async function runOllamaConverge(opts: { dryRun?: boolean } = {}): Promise<TierOutcome[]> {
-    console.log("\nConverging local models against the registry…");
+    // Announce the plan BEFORE any network transfer: which tiers are
+    // installed (and will be checked), that pulls can be large, and how to
+    // opt out. A 16 GB download must never be the first sign convergence
+    // is running.
+    let installedTiers: string[] = [];
+    try {
+        const res = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(5_000) });
+        if (res.ok) {
+            const data = (await res.json()) as { models?: Array<{ name: string }> };
+            const names = new Set((data.models ?? []).map((m) => m.name));
+            installedTiers = CONVERGE_TIERS.filter(
+                (t) => names.has(`${MODEL_NAMESPACE}:${t}`) || names.has(`${LOCAL_PREFIX}:${t}`),
+            );
+        }
+    } catch {
+        // convergeModels handles the unreachable case with its own message
+    }
+    if (installedTiers.length > 0) {
+        console.log(
+            `\nConverging ${installedTiers.length} installed model tier(s) [${installedTiers.join(", ")}] against the registry.`,
+        );
+        console.log(
+            "  Updated models download in full (can be multiple GB). Skip with: prism connect --no-models",
+        );
+    } else {
+        console.log("\nConverging local models against the registry…");
+    }
+
     const outcomes = await convergeModels({
         listTags: async () => {
             const res = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(5_000) });

--- a/tests/utils/modelConvergeRunner.test.ts
+++ b/tests/utils/modelConvergeRunner.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Tests — the runner's daemon-targeting env (adversarial review, pre-20.14.0).
+ *
+ * The defect this pins: listTags read /api/tags from PRISM_LOCAL_LLM_URL
+ * while spawned `ollama pull` / `ollama cp` used the shell's ambient
+ * OLLAMA_HOST (default localhost). With a remote Ollama configured,
+ * convergence read one daemon's tags and mutated another daemon's models.
+ * The spawn env must pin OLLAMA_HOST to the exact url the tags came from.
+ */
+import { describe, it, expect } from "vitest";
+import { convergeEnv } from "../../src/modelConvergeRunner.js";
+
+describe("convergeEnv", () => {
+    it("pins OLLAMA_HOST to the url the tags were read from", () => {
+        const env = convergeEnv({ PATH: "/usr/bin" }, "http://gpu-box:11434");
+        expect(env.OLLAMA_HOST).toBe("http://gpu-box:11434");
+        expect(env.PATH).toBe("/usr/bin");
+    });
+
+    it("OVERRIDES an ambient shell OLLAMA_HOST — the split-brain case", () => {
+        // Shell says remote, prism is configured for localhost: the CLI must
+        // act on the daemon prism reads tags from, not the shell's.
+        const env = convergeEnv(
+            { OLLAMA_HOST: "http://somewhere-else:9999" },
+            "http://localhost:11434",
+        );
+        expect(env.OLLAMA_HOST).toBe("http://localhost:11434");
+    });
+
+    it("does not mutate the input env object", () => {
+        const base: NodeJS.ProcessEnv = { OLLAMA_HOST: "http://a:1" };
+        convergeEnv(base, "http://b:2");
+        expect(base.OLLAMA_HOST).toBe("http://a:1");
+    });
+});


### PR DESCRIPTION
Adversarial review of #176 before cutting 20.14.0. Two findings, both fixed:

1. **Split-brain daemon targeting** — `listTags` read `PRISM_LOCAL_LLM_URL` while the spawned `ollama` CLI used the shell's ambient `OLLAMA_HOST` (default localhost). Remote-Ollama users would have tags read from one daemon and pulls/re-aliases applied to another. Spawn env now pins `OLLAMA_HOST` to the exact url tags came from; `convergeEnv()` unit-tested incl. overriding an ambient shell value.
2. **Silent multi-GB downloads** — the registry 27b changed bytes this week, so every 27b holder's first converge pulls ~16 GB with no forewarning. The tier plan and the `--no-models` escape hatch now print before any transfer.

Accepted with rationale: no pull timeout (legit 16 GB pulls outlive any sane timeout; failures never break connect); offline machines log and continue.

Live-verified idempotent on a real machine. 11 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)