### PR TITLE
fix(security): GHSA-9cvx-7x8q-3g6m — dashboard Host/Origin validation + default token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Security — dashboard DNS-rebinding fix (GHSA-9cvx-7x8q-3g6m)
+
+- **Fixed: the Mind Palace dashboard validates `Host`/`Origin` before serving
+  any `/api/*`, `/sse`, or `/messages` request.** The dashboard auto-starts on
+  every MCP boot, binds loopback, and ran with auth disabled by default — but
+  loopback binding does not stop DNS rebinding. A page the developer merely
+  visited could rebind its own hostname to `127.0.0.1`, reach the dashboard as
+  "same-origin" with an attacker `Host`/`Origin`, and read or export the whole
+  cross-project session-memory store with zero credentials. Requests whose
+  `Host`/`Origin` is not loopback (or the operator-configured
+  `PRISM_DASHBOARD_ORIGIN`) now get `403`, independent of whether auth is
+  configured. Route scoping uses the same WHATWG-normalized pathname the router
+  resolves, so a dot-segment target like `/x/../api/settings` cannot slip past
+  it (a live bypass caught in adversarial review).
+- **Added: the data API is gated by a per-startup token by default** (the
+  advisory's second remediation). With no auth configured, the dashboard mints a
+  random token and prints a tokenized URL to the startup log; opening it once
+  stores a `SameSite` cookie so the SPA authenticates transparently. Pin it with
+  `PRISM_DASHBOARD_TOKEN`, or disable it with `PRISM_DASHBOARD_NO_TOKEN=1` (the
+  `Host`/`Origin` guard still runs). Configuring Basic Auth or JWKS replaces the
+  token with that stronger gate. **Operator-visible change:** open the tokenized
+  URL from the log, not a bare `http://localhost:3000`.
+- 73 new security regression tests (`tests/dashboard/host-guard.test.ts`,
+  `tests/dashboard/dashboard-token.test.ts`); docs updated (README, IDE_SETUP,
+  WEB_SCHOLAR, examples).
+
 ## 20.14.0 — 2026-08-18
 
 ### Model convergence — `prism connect` now updates your models

--- a/README.md
+++ b/README.md
@@ -724,6 +724,12 @@ Every conversation feeds a persistent store. The next session loads the right co
 
 The dashboard shows your current project state, pending TODOs, intent health, and a neural knowledge graph — all built automatically from your agent sessions.
 
+It runs on loopback and is gated by a per-startup token by default — open the
+tokenized URL printed in the startup log (`http://localhost:3000/?token=…`).
+Requests with an untrusted `Host`/`Origin` are refused, closing the DNS-rebinding
+exposure fixed in GHSA-9cvx-7x8q-3g6m. See [docs/IDE_SETUP.md](docs/IDE_SETUP.md#securing-the-dashboard)
+to pin the token, disable it, or configure Basic Auth / JWKS.
+
 ### Export — read the record outside the agent
 
 `session_export_memory` writes your memory out as plain files you can read,

--- a/docs/IDE_SETUP.md
+++ b/docs/IDE_SETUP.md
@@ -436,10 +436,16 @@ The Mind Palace dashboard launches automatically alongside the MCP server.
 | Setting | Default | Notes |
 |---------|---------|-------|
 | Port | `3000` | Override with `PRISM_DASHBOARD_PORT` |
-| URL | `http://localhost:3000` | |
-| Auth | Disabled | See below for auth options |
+| URL | `http://localhost:3000/?token=…` | Tokenized URL printed to the startup log |
+| Access | Loopback-only + per-startup token | Host/Origin-validated; see below |
 
-Open `http://localhost:3000` (or your configured port) in a browser.
+**Open the tokenized URL printed in the Prism startup log**, e.g.
+`http://localhost:3000/?token=<random>`. Opening it once stores a `SameSite`
+cookie, so later visits to `http://localhost:3000` work for the rest of the
+session. The data API (`/api/*`) rejects requests without the token, and rejects
+any request whose `Host`/`Origin` is not loopback or your configured
+`PRISM_DASHBOARD_ORIGIN` — this closes the DNS-rebinding exposure fixed in
+GHSA-9cvx-7x8q-3g6m.
 
 The startup display reads Agent Name, Default Role, Context Depth, and Auto-Load
 Projects from this dashboard. Do not hardcode a project or depth in host rules;
@@ -447,6 +453,22 @@ use `session_bootstrap({})` (or `prism bootstrap`) so dashboard changes apply to
 every connected agent on its next conversation.
 
 ### Securing the dashboard
+
+**Default token (no config needed)** — with no auth configured, the dashboard
+mints a random token each startup and gates `/api/*` with it. Open the tokenized
+URL from the startup log. To control it:
+
+```json
+"env": {
+  "PRISM_DASHBOARD_TOKEN": "pin-a-stable-token",   // optional: reuse one URL
+  "PRISM_DASHBOARD_NO_TOKEN": "1",                  // optional: disable the token
+  "PRISM_DASHBOARD_ORIGIN": "https://prism.team.internal"  // trust a remote origin
+}
+```
+
+The `Host`/`Origin` allow-list runs in every mode (even with `PRISM_DASHBOARD_NO_TOKEN=1`),
+so a DNS-rebound browser is refused regardless. Configuring Basic Auth or JWKS
+below replaces the token with that stronger gate.
 
 **Basic Auth** — add to your MCP config env:
 

--- a/docs/WEB_SCHOLAR.md
+++ b/docs/WEB_SCHOLAR.md
@@ -91,7 +91,8 @@ node dist/server.js
 
 ### 4. Verify
 
-Open the Mind Palace Dashboard at `http://localhost:3333` and scroll to the **BACKGROUND SCHEDULER** section. You should see:
+Open the Mind Palace Dashboard using the tokenized URL from the startup log
+(e.g. `http://localhost:3333/?token=<random>`) and scroll to the **BACKGROUND SCHEDULER** section. You should see:
 
 ```
 Web Scholar: 🟢 Enabled (every 5m)

--- a/examples/multi-agent-hivemind/README.md
+++ b/examples/multi-agent-hivemind/README.md
@@ -129,7 +129,8 @@ On session end:
 
 ## Dashboard View
 
-Open `http://localhost:3000` to see the **Hivemind Radar** panel:
+Open the tokenized dashboard URL from the Prism startup log (e.g.
+`http://localhost:3000/?token=<random>`) to see the **Hivemind Radar** panel:
 - Active agent roster with roles, tasks, and heartbeat timestamps
 - Color-coded health indicators: 🟢 Active, 🟡 Stale, 🔴 Frozen, ⏰ Overdue, 🔄 Looping
 - Loop detection badges (if an agent repeats the same task 5+ times)

--- a/examples/vercel-ai-sdk-prism/README.md
+++ b/examples/vercel-ai-sdk-prism/README.md
@@ -21,7 +21,7 @@ cd examples/vercel-ai-sdk-prism
 cp .env.example .env.local        # add your OPENAI_API_KEY
 npm install
 npm run dev
-# → open http://localhost:3000
+# → open the tokenized dashboard URL from the startup log (http://localhost:3000/?token=…)
 ```
 
 The Prism Coder server is auto-spawned via `npx -y prism-mcp-server` (see `lib/prism-client.ts`). No separate process to manage.

--- a/src/dashboard/dashboardToken.ts
+++ b/src/dashboard/dashboardToken.ts
@@ -1,0 +1,73 @@
+import { randomBytes } from "crypto";
+import { safeCompare } from "./authUtils.js";
+
+/**
+ * Default-on per-request token for the dashboard data API — remediation #2 of
+ * GHSA-9cvx-7x8q-3g6m. Defense-in-depth ON TOP OF the Host/Origin guard: the
+ * token is minted at startup and surfaced only through the server's own stdout,
+ * so a DNS-rebound page (which never sees that log) cannot present it even if
+ * the Host guard were bypassed or an operator misconfigured the origin.
+ *
+ * Token mode is INACTIVE when the operator has configured real auth
+ * (PRISM_DASHBOARD_USER/PASS or JWKS) — that is the gate then — or when
+ * explicitly opted out via PRISM_DASHBOARD_NO_TOKEN for a trusted, local-only
+ * box. The Host guard still runs in every mode.
+ */
+
+export interface DashboardTokenConfig {
+  /** True when PRISM_DASHBOARD_USER/PASS or JWKS auth is configured. */
+  authEnabled: boolean;
+  /** Raw env PRISM_DASHBOARD_TOKEN — pin a known token instead of a random one. */
+  pinnedToken?: string;
+  /** Raw env PRISM_DASHBOARD_NO_TOKEN — opt out of the default token. */
+  optOut?: string;
+}
+
+function isTruthy(v: string | undefined): boolean {
+  const s = (v || "").trim().toLowerCase();
+  return s === "1" || s === "true" || s === "yes" || s === "on";
+}
+
+/**
+ * Resolve the active dashboard token, or null when token mode is off. A pinned
+ * token wins over a random one so operators can share a stable URL; an empty or
+ * whitespace-only pin is ignored (falls back to a random token).
+ */
+export function resolveDashboardToken(cfg: DashboardTokenConfig): string | null {
+  if (cfg.authEnabled) return null; // real auth is the gate
+  if (isTruthy(cfg.optOut)) return null; // explicit opt-out (Host guard still applies)
+  const pinned = (cfg.pinnedToken || "").trim();
+  if (pinned) return pinned;
+  return randomBytes(32).toString("hex");
+}
+
+/** Extract the prism_dashboard_token cookie value, if present. */
+export function tokenFromCookie(cookieHeader: string | undefined): string | null {
+  // Capture the whole value (any run of non-";", non-space) so pinned tokens
+  // with hyphens/underscores match; the name is anchored to start-or-"; " so a
+  // look-alike cookie (evil_prism_dashboard_token=…) cannot match.
+  const m = (cookieHeader || "").match(/(?:^|;\s*)prism_dashboard_token=([^;\s]+)/);
+  return m ? m[1] : null;
+}
+
+/**
+ * True when the request presents the active token via the cookie, the
+ * X-Prism-Dashboard-Token header, or a ?token= query param. Every comparison is
+ * timing-safe and only runs against the single active token.
+ */
+export function requestHasToken(
+  headers: { cookie?: string; headerToken?: string | null },
+  queryToken: string | null,
+  activeToken: string,
+): boolean {
+  const candidates = [tokenFromCookie(headers.cookie), headers.headerToken ?? null, queryToken];
+  return candidates.some((c) => c !== null && safeCompare(c, activeToken));
+}
+
+/** Build the Set-Cookie value that stores the token for a browser session. */
+export function buildTokenCookie(token: string, maxAgeMs: number, secure: boolean): string {
+  return (
+    `prism_dashboard_token=${token}; Path=/; HttpOnly; SameSite=Strict; ` +
+    `Max-Age=${Math.floor(maxAgeMs / 1000)}${secure ? "; Secure" : ""}`
+  );
+}

--- a/src/dashboard/hostGuard.ts
+++ b/src/dashboard/hostGuard.ts
@@ -1,0 +1,102 @@
+/**
+ * Host / Origin allow-listing for the Mind Palace dashboard.
+ *
+ * GHSA-9cvx-7x8q-3g6m: the dashboard auto-starts on every MCP boot, binds
+ * loopback, and by default runs with auth disabled. Loopback binding does NOT
+ * stop DNS rebinding — a page the developer merely visits can rebind its own
+ * hostname to 127.0.0.1 and reach this server as "same-origin", carrying an
+ * attacker-chosen Host/Origin. The server must therefore reject any request
+ * whose Host (or, when present, Origin) is not a trusted local name or the
+ * operator-configured public origin, BEFORE any route runs and independent of
+ * whether auth is configured. This mirrors the standard fix for the class
+ * (Host-header validation, cf. CVE-2025-10193).
+ *
+ * Matching by hostname only (port-agnostic) is deliberate and safe: the attack
+ * requires an attacker-controlled *name*, so `localhost` / `127.0.0.1` / `[::1]`
+ * are trustworthy on any port — which also keeps the guard correct when the
+ * server falls back to PORT+1/PORT+2 on an address-in-use conflict.
+ */
+
+export interface HostGuardConfig {
+  /** Operator-configured public origin, e.g. https://prism.team.example. */
+  configuredOrigin?: string;
+}
+
+/** Loopback host names browsers use for the local dashboard. Exact match only. */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+/**
+ * Lowercased hostname (never the port) of a Host authority (`host[:port]`) or a
+ * full Origin URL. Returns null when the value cannot be parsed — a malformed or
+ * opaque value (e.g. the literal `null` Origin) is never trusted.
+ */
+function hostnameOf(value: string, asUrl = false): string | null {
+  try {
+    const u = asUrl ? new URL(value) : new URL(`http://${value}`);
+    return u.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/** The set of hostnames that may be served: loopback + configured origin. */
+function trustedHostnames(cfg: HostGuardConfig): Set<string> {
+  const names = new Set(LOOPBACK_HOSTNAMES);
+  if (cfg.configuredOrigin) {
+    const h = hostnameOf(cfg.configuredOrigin, true);
+    if (h) names.add(h);
+  }
+  return names;
+}
+
+/**
+ * True when a request target addresses a sensitive dashboard route — the memory
+ * API (`/api/*`) or the MCP HTTP transport (`/sse`, `/messages`) — and must
+ * therefore pass the Host/Origin gate.
+ *
+ * Scoping MUST use the same normalized pathname the router resolves, or a
+ * dot-segment target like `/x/../api/settings` slips past a raw-string prefix
+ * check while the router still collapses it to `/api/settings` and serves the
+ * data. A fixed base keeps this independent of the attacker-supplied Host; an
+ * unparseable target is treated as guarded (fail closed). Public routes (the
+ * static shell, PWA assets, the Smithery manifest) carry no session data and
+ * are intentionally out of scope.
+ */
+export function isRebindGuardedPath(requestTarget: string | undefined): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(requestTarget || "/", "http://prism-dashboard.invalid").pathname;
+  } catch {
+    return true; // unparseable target → fail closed
+  }
+  return pathname.startsWith("/api/") || pathname === "/sse" || pathname === "/messages";
+}
+
+/** True when the HTTP Host header names a trusted local or configured host. */
+export function isTrustedHost(hostHeader: string | undefined, cfg: HostGuardConfig): boolean {
+  if (!hostHeader) return false; // HTTP/1.1 requires Host; absence is not trusted.
+  const name = hostnameOf(hostHeader);
+  return name !== null && trustedHostnames(cfg).has(name);
+}
+
+/**
+ * True when the Origin header (if the request carries one) is trusted. A request
+ * with no Origin — a top-level navigation or a non-CORS GET — is not rejected on
+ * Origin grounds; the Host check is the load-bearing gate there.
+ */
+export function isTrustedOrigin(originHeader: string | undefined, cfg: HostGuardConfig): boolean {
+  if (!originHeader) return true; // absent Origin defers to the Host check
+  const name = hostnameOf(originHeader, true);
+  return name !== null && trustedHostnames(cfg).has(name);
+}
+
+/**
+ * Combined DNS-rebinding gate: the request must pass BOTH the Host and the
+ * (when present) Origin check. Call this before serving any sensitive route.
+ */
+export function isTrustedRequest(
+  headers: { host?: string; origin?: string },
+  cfg: HostGuardConfig,
+): boolean {
+  return isTrustedHost(headers.host, cfg) && isTrustedOrigin(headers.origin, cfg);
+}

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -37,6 +37,11 @@ import { handleGraphRoutes } from "./graphRouter.js";
 import { isDashboardSettingKeyAllowed, isDashboardSettingValueAllowed } from "./settingsPolicy.js";
 import { isTrustedRequest, isRebindGuardedPath } from "./hostGuard.js";
 import {
+  resolveDashboardToken,
+  requestHasToken,
+  buildTokenCookie,
+} from "./dashboardToken.js";
+import {
   safeCompare,
   generateToken,
   isAuthenticated,
@@ -113,6 +118,18 @@ export async function startDashboardServer(): Promise<void> {
 
   const SESSION_TTL_MS = parseInt(process.env.PRISM_SESSION_TTL_MS ?? String(24 * 60 * 60 * 1000), 10);
   const activeSessions = new Map<string, number>();
+
+  // ─── SECURITY: default-on dashboard token (GHSA-9cvx-7x8q-3g6m, remediation #2) ───
+  // Null when real auth is configured (that is the gate) or explicitly opted
+  // out; otherwise a random per-startup secret gates the data API as a second
+  // layer beneath the Host guard. Surfaced only in the startup log below.
+  const DASHBOARD_TOKEN = resolveDashboardToken({
+    authEnabled: AUTH_ENABLED,
+    pinnedToken: process.env.PRISM_DASHBOARD_TOKEN,
+    optOut: process.env.PRISM_DASHBOARD_NO_TOKEN,
+  });
+  const COOKIE_SECURE =
+    !!process.env.PRISM_DASHBOARD_ORIGIN?.startsWith("https://") || !!process.env.PRISM_DASHBOARD_SECURE;
 
   // Auth config object — injectable for testing via authUtils.ts
   const authConfig: AuthConfig = {
@@ -247,6 +264,48 @@ return false;}
 
     // ─── v5.1: Auth login endpoint (always accessible) ───
     const reqUrl = new URL(req.url || "/", `http://${req.headers.host}`);
+
+    // ─── SECURITY: dashboard token gate (GHSA-9cvx-7x8q-3g6m, remediation #2) ───
+    // Second layer beneath the Host guard. Inert when DASHBOARD_TOKEN is null
+    // (real auth configured, or opted out). A page load carrying a valid ?token=
+    // is bootstrapped into a SameSite cookie so the SPA's later same-origin
+    // fetches authenticate transparently; the data API otherwise requires the
+    // token via cookie, X-Prism-Dashboard-Token header, or ?token= query.
+    if (DASHBOARD_TOKEN) {
+      const qToken = reqUrl.searchParams.get("token");
+      const isApiPath = reqUrl.pathname.startsWith("/api/");
+
+      if (!isApiPath && qToken && safeCompare(qToken, DASHBOARD_TOKEN)) {
+        reqUrl.searchParams.delete("token");
+        const cleanTarget = reqUrl.pathname + (reqUrl.search ? reqUrl.search : "");
+        res.writeHead(302, {
+          "Set-Cookie": buildTokenCookie(DASHBOARD_TOKEN, SESSION_TTL_MS, COOKIE_SECURE),
+          Location: cleanTarget,
+        });
+        return res.end();
+      }
+
+      if (
+        isApiPath &&
+        !requestHasToken(
+          {
+            cookie: req.headers.cookie,
+            headerToken: (req.headers["x-prism-dashboard-token"] as string) || null,
+          },
+          qToken,
+          DASHBOARD_TOKEN,
+        )
+      ) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        return res.end(
+          JSON.stringify({
+            error:
+              "Dashboard token required — open the tokenized URL printed in the Prism startup log.",
+          }),
+        );
+      }
+    }
+
     if (AUTH_ENABLED && reqUrl.pathname === "/api/auth/login" && req.method === "POST") {
       // v6.5.1: Rate limiting — prevent brute-force attacks
       const clientIP = (req.socket?.remoteAddress || "unknown").replace(/^::ffff:/, "");
@@ -310,7 +369,8 @@ return false;}
             version: SERVER_CONFIG.version,
           },
           authentication: {
-            required: AUTH_ENABLED
+            // True when either configured auth or the default token gate is active.
+            required: AUTH_ENABLED || !!DASHBOARD_TOKEN
           },
           configSchema: {
             type: "object",
@@ -1496,7 +1556,17 @@ self.addEventListener('message', (e) => {
     // Non-fatal — just means the user has to know the port
   }
 
-  console.error(`[Prism] 🧠 Mind Palace Dashboard → http://localhost:${boundPort}`);
+  if (DASHBOARD_TOKEN) {
+    console.error(
+      `[Prism] 🔐 Mind Palace Dashboard → http://localhost:${boundPort}/?token=${DASHBOARD_TOKEN}`
+    );
+    console.error(
+      `[Prism]    Data API is token-gated by default (GHSA-9cvx-7x8q-3g6m). Open the URL above once; ` +
+      `pin it with PRISM_DASHBOARD_TOKEN, or disable with PRISM_DASHBOARD_NO_TOKEN=1.`
+    );
+  } else {
+    console.error(`[Prism] 🧠 Mind Palace Dashboard → http://localhost:${boundPort}`);
+  }
 
   // ─── v3.1: TTL Sweep — runs at startup + every 12 hours ───────────
   // NOTE (v5.4): The Background Scheduler in server.ts now also handles

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -35,6 +35,7 @@ import { buildVaultDirectory } from "../utils/vaultExporter.js";
 import { redactSettings } from "../tools/commonHelpers.js";
 import { handleGraphRoutes } from "./graphRouter.js";
 import { isDashboardSettingKeyAllowed, isDashboardSettingValueAllowed } from "./settingsPolicy.js";
+import { isTrustedRequest, isRebindGuardedPath } from "./hostGuard.js";
 import {
   safeCompare,
   generateToken,
@@ -222,6 +223,26 @@ return false;}
     if (req.method === "OPTIONS") {
       res.writeHead(204);
       return res.end();
+    }
+
+    // ─── SECURITY: Host / Origin allow-list (GHSA-9cvx-7x8q-3g6m) ───
+    // Reject DNS-rebinding requests before any sensitive route runs, independent
+    // of AUTH_ENABLED. A rebound browser reaches this loopback server carrying an
+    // attacker-controlled Host/Origin; only a trusted local name or the operator-
+    // configured PRISM_DASHBOARD_ORIGIN may be served the memory API / MCP
+    // transport. The public Smithery manifest (/.well-known/...) is intentionally
+    // left out of scope — it exposes no session data.
+    if (
+      isRebindGuardedPath(req.url) &&
+      !isTrustedRequest(
+        { host: req.headers.host, origin: req.headers.origin },
+        { configuredOrigin: process.env.PRISM_DASHBOARD_ORIGIN },
+      )
+    ) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      return res.end(
+        JSON.stringify({ error: "Forbidden: untrusted Host or Origin (possible DNS rebinding)" }),
+      );
     }
 
     // ─── v5.1: Auth login endpoint (always accessible) ───

--- a/tests/dashboard/dashboard-token.test.ts
+++ b/tests/dashboard/dashboard-token.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Default-on dashboard token — remediation #2 of GHSA-9cvx-7x8q-3g6m.
+ *
+ * The token is defense-in-depth beneath the Host guard: a secret minted at
+ * startup and shown only in the server's stdout, so a DNS-rebound page cannot
+ * present it. These cases pin when the token is active, how it is matched, and
+ * that matching is exact and constant-time-safe (length-mismatch → false).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  resolveDashboardToken,
+  requestHasToken,
+  tokenFromCookie,
+  buildTokenCookie,
+} from "../../src/dashboard/dashboardToken.js";
+
+describe("dashboard token gate (GHSA-9cvx-7x8q-3g6m #2)", () => {
+  describe("resolveDashboardToken", () => {
+    it("mints a random 64-hex token on a default (no-auth) install", () => {
+      const t = resolveDashboardToken({ authEnabled: false });
+      expect(t).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it("mints a DIFFERENT token each call (not a fixed constant)", () => {
+      const a = resolveDashboardToken({ authEnabled: false });
+      const b = resolveDashboardToken({ authEnabled: false });
+      expect(a).not.toBe(b);
+    });
+
+    it("is off when real auth is configured — that is the gate then", () => {
+      expect(resolveDashboardToken({ authEnabled: true })).toBeNull();
+    });
+
+    it.each(["1", "true", "TRUE", "yes", "on"])(
+      "honors the PRISM_DASHBOARD_NO_TOKEN opt-out value %s",
+      (optOut) => {
+        expect(resolveDashboardToken({ authEnabled: false, optOut })).toBeNull();
+      },
+    );
+
+    it.each(["", "  ", "0", "false", "no", undefined])(
+      "keeps the token active for non-opt-out value %s",
+      (optOut) => {
+        expect(resolveDashboardToken({ authEnabled: false, optOut })).not.toBeNull();
+      },
+    );
+
+    it("pins a provided token verbatim, ignoring a whitespace-only pin", () => {
+      expect(resolveDashboardToken({ authEnabled: false, pinnedToken: "PINNED-abc123" })).toBe(
+        "PINNED-abc123",
+      );
+      expect(resolveDashboardToken({ authEnabled: false, pinnedToken: "   " })).toMatch(
+        /^[a-f0-9]{64}$/,
+      );
+    });
+
+    it("does not pin when auth is enabled (auth wins over a pin)", () => {
+      expect(
+        resolveDashboardToken({ authEnabled: true, pinnedToken: "PINNED-abc123" }),
+      ).toBeNull();
+    });
+  });
+
+  describe("tokenFromCookie", () => {
+    it("extracts the token from a cookie header among others", () => {
+      expect(tokenFromCookie("foo=1; prism_dashboard_token=abc123; bar=2")).toBe("abc123");
+      expect(tokenFromCookie("prism_dashboard_token=xyz")).toBe("xyz");
+    });
+
+    it("returns null when absent, empty, or a look-alike cookie name", () => {
+      expect(tokenFromCookie(undefined)).toBeNull();
+      expect(tokenFromCookie("")).toBeNull();
+      expect(tokenFromCookie("other=1")).toBeNull();
+      // a differently-named cookie sharing the suffix must NOT match — the name
+      // is anchored to start-of-header or "; ".
+      expect(tokenFromCookie("evil_prism_dashboard_token=abc")).toBeNull();
+      expect(tokenFromCookie("xprism_dashboard_token=abc")).toBeNull();
+    });
+  });
+
+  describe("requestHasToken", () => {
+    const ACTIVE = "s3cr3t-active-token";
+
+    it("accepts the token via cookie", () => {
+      expect(
+        requestHasToken({ cookie: `prism_dashboard_token=${ACTIVE}` }, null, ACTIVE),
+      ).toBe(true);
+    });
+
+    it("accepts the token via X-Prism-Dashboard-Token header", () => {
+      expect(requestHasToken({ headerToken: ACTIVE }, null, ACTIVE)).toBe(true);
+    });
+
+    it("accepts the token via ?token= query", () => {
+      expect(requestHasToken({}, ACTIVE, ACTIVE)).toBe(true);
+    });
+
+    it("rejects when no channel carries the token", () => {
+      expect(requestHasToken({}, null, ACTIVE)).toBe(false);
+      expect(requestHasToken({ cookie: "prism_dashboard_token=" }, null, ACTIVE)).toBe(false);
+    });
+
+    it("rejects a wrong or truncated token (exact match only)", () => {
+      expect(requestHasToken({ headerToken: "wrong" }, null, ACTIVE)).toBe(false);
+      expect(requestHasToken({ headerToken: ACTIVE.slice(0, -1) }, null, ACTIVE)).toBe(false);
+      expect(requestHasToken({ cookie: `prism_dashboard_token=${ACTIVE}x` }, null, ACTIVE)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("buildTokenCookie", () => {
+    it("is HttpOnly + SameSite=Strict with a whole-second Max-Age", () => {
+      const c = buildTokenCookie("tok", 86_400_000, false);
+      expect(c).toContain("prism_dashboard_token=tok");
+      expect(c).toContain("HttpOnly");
+      expect(c).toContain("SameSite=Strict");
+      expect(c).toContain("Max-Age=86400");
+      expect(c).not.toContain("Secure");
+    });
+
+    it("adds Secure when requested", () => {
+      expect(buildTokenCookie("tok", 1000, true)).toContain("; Secure");
+    });
+  });
+});

--- a/tests/dashboard/host-guard.test.ts
+++ b/tests/dashboard/host-guard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * DNS-rebinding Host/Origin guard for the Mind Palace dashboard.
+ *
+ * GHSA-9cvx-7x8q-3g6m: with auth disabled by default and no Host/Origin check,
+ * a DNS-rebound browser reached the loopback dashboard carrying an attacker
+ * Host/Origin and read/exported the developer's whole session memory. The
+ * existing dashboard suites only exercise the happy path (loopback requests),
+ * so the reject branch that closes the vuln was never asserted. These cases pin
+ * it directly, mirroring the negative-branch coverage added for the two July
+ * advisories.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isTrustedHost,
+  isTrustedOrigin,
+  isTrustedRequest,
+  isRebindGuardedPath,
+} from "../../src/dashboard/hostGuard.js";
+
+const NO_ORIGIN = {}; // default install: auth off, no operator origin configured
+
+describe("dashboard DNS-rebinding host guard (GHSA-9cvx-7x8q-3g6m)", () => {
+  it.each([
+    "localhost:3000",
+    "localhost",
+    "127.0.0.1:3000",
+    "127.0.0.1",
+    "[::1]:3000",
+    "[::1]",
+    "localhost:3001", // bound-port fallback (PORT+1 on conflict) must stay trusted
+    "localhost:8089", // the port used in the advisory PoC
+  ])("trusts the loopback Host %s on any port", (host) => {
+    expect(isTrustedHost(host, NO_ORIGIN)).toBe(true);
+  });
+
+  it.each([
+    "attacker.example:3000",
+    "attacker.example",
+    "prism.attacker.test",
+    "169.254.169.254", // cloud metadata
+    "evil.localhost.attacker.com", // substring 'localhost' must not leak
+    "127.0.0.1.attacker.com", // substring '127.0.0.1' must not leak
+  ])("rejects the forged Host %s", (host) => {
+    expect(isTrustedHost(host, NO_ORIGIN)).toBe(false);
+  });
+
+  it("rejects a missing Host header", () => {
+    expect(isTrustedHost(undefined, NO_ORIGIN)).toBe(false);
+  });
+
+  it("trusts only the operator-configured origin host, not look-alikes", () => {
+    const cfg = { configuredOrigin: "https://prism.team.example" };
+    expect(isTrustedHost("prism.team.example", cfg)).toBe(true);
+    expect(isTrustedHost("prism.team.example:443", cfg)).toBe(true);
+    expect(isTrustedHost("prism.team.example.attacker.com", cfg)).toBe(false);
+    expect(isTrustedHost("attacker.example", cfg)).toBe(false);
+  });
+
+  describe("Origin header", () => {
+    it("defers to the Host check when Origin is absent", () => {
+      expect(isTrustedOrigin(undefined, NO_ORIGIN)).toBe(true);
+    });
+
+    it("trusts a loopback Origin", () => {
+      expect(isTrustedOrigin("http://localhost:3000", NO_ORIGIN)).toBe(true);
+    });
+
+    it.each([
+      "http://attacker.example:3000",
+      "null", // sandboxed / opaque origin
+      "http://127.0.0.1.attacker.com",
+    ])("rejects the forged or opaque Origin %s", (origin) => {
+      expect(isTrustedOrigin(origin, NO_ORIGIN)).toBe(false);
+    });
+  });
+
+  describe("combined request gate", () => {
+    it("serves a legitimate same-origin dashboard request", () => {
+      expect(
+        isTrustedRequest({ host: "localhost:3000", origin: "http://localhost:3000" }, NO_ORIGIN),
+      ).toBe(true);
+    });
+
+    it("blocks the exact DNS-rebinding request shape from the advisory PoC", () => {
+      // GET /api/settings  Host: attacker.example:8089  Origin: http://attacker.example:8089
+      expect(
+        isTrustedRequest(
+          { host: "attacker.example:8089", origin: "http://attacker.example:8089" },
+          NO_ORIGIN,
+        ),
+      ).toBe(false);
+    });
+
+    it("blocks a rebound Host even when the Origin header is stripped", () => {
+      expect(isTrustedRequest({ host: "attacker.example:3000" }, NO_ORIGIN)).toBe(false);
+    });
+
+    it("blocks a loopback Host paired with a forged Origin", () => {
+      // A rebound page cannot forge both to loopback, but pin the AND semantics.
+      expect(
+        isTrustedRequest(
+          { host: "127.0.0.1:3000", origin: "http://attacker.example:3000" },
+          NO_ORIGIN,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  // The guard's route scoping must match the router's NORMALIZED pathname, or a
+  // dot-segment path slips past a raw-string prefix check while the router still
+  // serves the data. This class was a live bypass caught in adversarial review:
+  // `--path-as-is /x/../api/settings` with a forged Host returned 200 + settings.
+  describe("guarded-route scoping (path normalization)", () => {
+    it.each([
+      "/api/settings",
+      "/api/project?name=x",
+      "/api/export/vault?project=x",
+      "/sse",
+      "/messages",
+      "/messages?sessionId=x",
+      "/x/../api/settings", // dot-segment collapses to /api/settings — the bypass
+      "/api/../api/export/vault",
+      "/./api/project",
+      "/x/..\\api/settings", // backslash is normalized to a slash for http URLs
+      "/sse/../sse",
+    ])("guards the sensitive target %s", (target) => {
+      expect(isRebindGuardedPath(target)).toBe(true);
+    });
+
+    it.each([
+      "/",
+      "/index.html",
+      "/manifest.json",
+      "/sw.js",
+      "/offline.html",
+      "/icon-192.svg",
+      "/apple-touch-icon.png",
+      "/.well-known/mcp/server-card.json", // public Smithery manifest — no session data
+      "/SSE", // routes are case-sensitive; router won't serve this either
+      "//api/settings", // protocol-relative → pathname is /settings, no /api route
+      "/api%2fsettings", // %2f stays encoded; matches no /api/* route
+    ])("leaves the public/non-data target %s out of scope", (target) => {
+      expect(isRebindGuardedPath(target)).toBe(false);
+    });
+
+    it("fails closed on an unparseable request target", () => {
+      // If the path can't be parsed we cannot prove it is public, so guard it.
+      expect(isRebindGuardedPath("http://[")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes **GHSA-9cvx-7x8q-3g6m** (DNS rebinding → full session-memory read/export via the Mind Palace dashboard).

## The vulnerability
The dashboard auto-starts on every MCP boot, binds loopback, and runs with auth disabled by default. Loopback binding does **not** stop DNS rebinding: a page the developer visits can rebind its own hostname to `127.0.0.1`, reach the dashboard as "same-origin" carrying an attacker `Host`/`Origin`, and read or `Export Vault` the entire cross-project session-memory store with zero credentials. Reproduced live against `main` (v20.14.0).

## Remediation #1 — Host/Origin validation (commit `fef4afb0b`)
- New `src/dashboard/hostGuard.ts`: port-agnostic allow-list of loopback names + operator-configured `PRISM_DASHBOARD_ORIGIN`; malformed/opaque values (missing `Host`, `Origin: null`) fail closed.
- `403` on any `/api/*`, `/sse`, `/messages` request with an untrusted `Host`/`Origin`, **before routing and independent of `AUTH_ENABLED`**.
- Route scoping uses the **same WHATWG-normalized pathname the router resolves** — adversarial review found a raw-string prefix check let `/x/../api/settings` (which the router collapses to `/api/settings`) slip past; a live `--path-as-is` request with a forged `Host` returned `200` + settings. Fixed and pinned by tests.

## Remediation #2 — default-on token (commit `a61102338`)
- New `src/dashboard/dashboardToken.ts`: with no auth configured, mint a random per-startup token (or pin via `PRISM_DASHBOARD_TOKEN`); gate `/api/*` on it via cookie / `X-Prism-Dashboard-Token` header / `?token=`. Surfaced only in the startup log, so a rebound page can't present it even if the Host guard were bypassed.
- A page load with a valid `?token=` is bootstrapped into a `SameSite=Strict` cookie (302 → clean URL), so the existing SPA client authenticates transparently — **`ui.ts` is unchanged**.
- `/sse` + `/messages` stay on the Host guard (HTTP MCP clients can't carry the token). Opt out with `PRISM_DASHBOARD_NO_TOKEN=1` (Host guard still runs). Basic Auth / JWKS replace the token with that stronger gate.

**Operator-visible change:** open the tokenized URL from the startup log, not a bare `http://localhost:3000`. Docs updated (README, `docs/IDE_SETUP.md`, `docs/WEB_SCHOLAR.md`, two example READMEs); CHANGELOG entry added.

## Tests & evidence
- **73 new regression tests** (`tests/dashboard/host-guard.test.ts` 48, `tests/dashboard/dashboard-token.test.ts` 25). Full dashboard suite **211 green**, `tsc` clean.
- Live matrix (dist, isolated `$HOME`): forged-`Host` `/api/settings|/api/project|/api/export/vault|/api/skills|/sse` → **403** (was 200); dot-segment + backslash variants → **403**; no-token `/api` → **401**; `?token`/header/cookie bootstrap → **200**; forged `Host` + valid token → **403** (Host guard first); public manifest + static shell → **200**.

Follows the same remediation shape as the July advisories (extracted testable guard + dedicated regression suite + surgical wiring). Standard fix for the class (Host-header validation, cf. CVE-2025-10193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)