### PR TITLE
fix(deps): clear all eight open Dependabot advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "postcss": "8.5.23",
         "quickjs-emscripten": "^0.32.0",
         "smol-toml": "^1.7.0",
-        "stream-json": "^2.0.0",
+        "stream-chain": "^4.2.5",
+        "stream-json": "^3.6.0",
         "tldts": "^7.0.27",
         "turndown": "^7.2.2",
         "zod": "^4.3.6"
@@ -226,6 +227,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -272,32 +274,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -307,7 +286,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1650,6 +1628,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3158,9 +3137,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3272,6 +3251,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3336,9 +3316,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3393,9 +3373,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/finalhandler": {
@@ -3549,9 +3529,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3565,6 +3545,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4528,6 +4509,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4632,12 +4614,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -4934,14 +4917,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -4953,13 +4936,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5057,21 +5040,24 @@
       "license": "MIT"
     },
     "node_modules/stream-chain": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.6.1.tgz",
-      "integrity": "sha512-M4BQpNPI71uumkVXjl4y+mIormQXdo4R0pSR23mcLbn6D+kpvu7Kx2g1hf0jRB76Zb1IT1M06OIGghMTAtZdyQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-4.2.5.tgz",
+      "integrity": "sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=22"
+      },
       "funding": {
         "url": "https://github.com/sponsors/uhop"
       }
     },
     "node_modules/stream-json": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-2.1.0.tgz",
-      "integrity": "sha512-9gV/ywtebMn3DdKnNKYCb9iESvgR1dHbucNV+bRGvdvy+jV4c9FFgYKmENhpKv58jSwvs90Wk80RhfKk1KxHPg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-3.6.0.tgz",
+      "integrity": "sha512-NiJdqxKyau579z/E8vfqcjWfSDWxW/AT99javFXdPXF147Z5za85LRXSHEmSX9TKOakB7gaIccfD0fOIctb7KQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "stream-chain": "^3.6.1"
+        "stream-chain": "^4.2.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/uhop"
@@ -5213,6 +5199,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -5324,6 +5311,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5645,6 +5633,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,7 +227,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -274,9 +273,32 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -286,6 +308,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1628,7 +1651,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3251,7 +3273,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3545,7 +3566,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
       "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4509,7 +4529,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5199,7 +5218,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -5311,7 +5329,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5633,7 +5650,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "overrides": {
     "@hono/node-server": "^2.0.5",
     "body-parser": "^2.3.0",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.6",
     "hono": "^4.12.27",
     "ip-address": "^10.2.0",
     "protobufjs": "^7.6.5",
@@ -109,7 +109,8 @@
     "postcss": "8.5.23",
     "quickjs-emscripten": "^0.32.0",
     "smol-toml": "^1.7.0",
-    "stream-json": "^2.0.0",
+    "stream-chain": "^4.2.5",
+    "stream-json": "^3.6.0",
     "tldts": "^7.0.27",
     "turndown": "^7.2.2",
     "zod": "^4.3.6"

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -82,6 +82,32 @@ describe('Migration Utility', () => {
       expect(turns).toHaveLength(2);
       expect(turns[1].role).toBe('assistant');
     });
+
+    // Guards the stream-json contract the adapter depends on: every array
+    // element is delivered exactly once, in source order, as { key, value }.
+    // stream-json 3.x is a major bump over the 2.x this was written against,
+    // and a silently truncating or reordering streamer would corrupt an
+    // import without failing anything above.
+    it('should stream every array element once, in order', async () => {
+      const filePath = path.join(TMP_DIR, 'gemini-large.json');
+      const entries = Array.from({ length: 500 }, (_, i) => ({
+        role: i % 2 === 0 ? 'user' : 'model',
+        parts: [{ text: `turn-${i}` }],
+        createTime: new Date(Date.UTC(2024, 0, 1, 0, 0, i)).toISOString(),
+      }));
+      fs.writeFileSync(filePath, JSON.stringify(entries));
+
+      const turns: any[] = [];
+      await geminiAdapter.parse(filePath, async (turn) => {
+        turns.push(turn);
+      });
+
+      expect(turns).toHaveLength(entries.length);
+      expect(turns.map(t => t.content)).toEqual(entries.map((_, i) => `turn-${i}`));
+      expect(turns.map(t => t.role)).toEqual(
+        entries.map((_, i) => (i % 2 === 0 ? 'user' : 'assistant')),
+      );
+    });
   });
 
   describe('OpenAI Adapter', () => {


### PR DESCRIPTION
Closes every open Dependabot alert on the repo — 4 high, 4 moderate — in one lockfile pass. `npm audit` reports 0 vulnerabilities; `npm audit --audit-level=high` (the CI gate) exits clean.

| Package | Was | Now | Advisory | Sev |
|---|---|---|---|---|
| fast-uri | 3.1.5 | 3.1.7 | GHSA-5jgf-p345-68v8, GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp | high ×4 |
| qs | 6.15.2 | 6.16.0 | GHSA-x5fp-wj9c-mxmx | moderate |
| fflate | 0.8.2 | 0.8.3 | GHSA-px8p-9vwx-vf98 | moderate |
| stream-json | 2.1.0 | 3.6.0 | GHSA-528h-pc64-c93x (alerts on both package.json and the lockfile) | moderate ×2 |

Supersedes #180, which bumps fast-uri alone.

Against `main` the lockfile package set is unchanged — nothing added, nothing removed. The only version moves are the four bumps above plus the transitive companions qs pulls in: `es-object-atoms`, `hasown`, `side-channel`, `side-channel-list`, and `stream-chain` 3.6.1 → 4.2.5 under stream-json.

### Why the `overrides` floor moved too

`overrides.fast-uri` went `^3.1.4` → `^3.1.6`. That override exists to force fast-uri up; leaving the floor inside the vulnerable range lets a future resolve land back on 3.1.4/3.1.5 while the lockfile still looks patched.

### Why stream-json is a major bump

No 2.x patch exists — 3.5.0 is the first fixed release. 3.6.0 rather than 3.5.0 because **3.5.0 declares `engines: node >= 22`** and the CI matrix still tests 20.x. 3.6.0 drops that constraint, and the compiled adapter was exercised on v20.20.2 to confirm it actually runs there, not just that npm stops complaining.

The API surface the adapters use is unchanged across the major: `StreamArray.withParser()` still emits `{ key, value }` per element, in order, through `chain()`.

### stream-chain becomes an explicit dependency

`geminiAdapter.ts` and `openaiAdapter.ts` both `import { chain } from 'stream-chain'`, but only stream-json declared it — the direct import was resolving through a hoisted phantom. This bump moves that phantom across a major (3.6.1 → 4.2.5). Declaring it makes the version our code imports a version we control.

### Test

The existing Gemini/OpenAI fixtures are two-element arrays, and they pass even against a streamer that stops after ten elements — so they do not actually cover the streaming contract this bump changes. The new test pins it: 500 elements, each delivered exactly once, in source order. Mutation-verified — truncating the adapter's loop at 10 fails the new test and only the new test.

### Generate this lockfile with npm 10, not npm 11

The first push failed all six `cli-integration` legs on `npm ci`:

```
npm error Missing: @emnapi/runtime@1.11.3 from lock file
npm error Missing: @emnapi/core@1.11.3 from lock file
```

Those two are optional peers of wasm32-only bindings that no CI platform installs — but npm 10 refuses the lockfile over the *absence of the entry*, not over whether it would install the package. npm 11.6.2 prunes them on any re-resolve; this repo's lockfile is written by npm 10, which is what `actions/setup-node` bundles (10.8.2 on Node 20, 10.9.8 on Node 22). The lockfile here is regenerated from main's with npm 10.9.8 and validates under all three.

Worth pinning npm in CI, or adding a lockfile-drift check, so this cannot recur silently — happy to do that in a follow-up if you want it.

### Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **4520 passed, 49 skipped, 0 failed** (191 files)
- `npm ci` under npm 10.9.8 — clean, lockfile left byte-identical; `npm ci --dry-run` clean under 10.8.2 and 11.6.2 as well
- `npm run build` clean, then the compiled `geminiAdapter` parsed a 300-entry export under **Node v20.20.2**: 300 turns, in order, roles correct
- `npm audit --audit-level=high` — 0 vulnerabilities
- private-repo leak guard, `no-raw-inference.mjs`, `check-no-private-content.mjs` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)