### PR TITLE
fix(skills): preserve routed rules across compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## 20.18.1 — 2026-09-12
+
+### Task-skill continuity across compaction and manifest updates
+
+- Restores the three most recently active prompt-routed task skills together
+  with the protected-floor digest after `SessionStart(source=compact)`.
+- Detects a newly materialized managed-skill generation and re-injects current,
+  re-authorized task bodies on the next prompt, including short `continue`
+  turns. A prompt that matches another skill retains the prior active rules.
+- Prevents stale managed paid skills from using the user-owned local-skill
+  entitlement exception during interrupted syncs or downgrades.
+- Injects the actual body of a prompt-matched user-owned local skill even when
+  signed out, while an entitled platform body wins any same-name collision.
+- Anchors injected context to the user's preceding request for Codex's trailing
+  developer-message placement and includes the anchor inside the host budget.
+- Bounds and validates hook state before forming CLI arguments, keeps the two
+  worst-case CLI waits below the host timeout, and makes the v5 script reject
+  stale v4 command invocations so rewritten code never inherits old trust.
+- Upgrade procedure: `prism connect --refresh --no-models`, then trust both v5
+  entries in Codex `/hooks`. Restart only when the running host has not reloaded
+  the new definitions; subsequent skill-content generations refresh in place.
+
 ## 20.18.0 — 2026-09-01
 
 ### Protected-floor digest in the bootstrap + post-compaction re-injection

--- a/README.md
+++ b/README.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_ar.md
+++ b/docs/i18n/README_ar.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_de.md
+++ b/docs/i18n/README_de.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_es.md
+++ b/docs/i18n/README_es.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_fr.md
+++ b/docs/i18n/README_fr.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_ja.md
+++ b/docs/i18n/README_ja.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_ko.md
+++ b/docs/i18n/README_ko.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_pt.md
+++ b/docs/i18n/README_pt.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_ro.md
+++ b/docs/i18n/README_ro.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_ru.md
+++ b/docs/i18n/README_ru.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_uk.md
+++ b/docs/i18n/README_uk.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/docs/i18n/README_zh.md
+++ b/docs/i18n/README_zh.md
@@ -145,6 +145,36 @@ or by re-enabling after each run.
 <details>
 <summary>Release history (optional)</summary>
 
+## What's New in v20.18.1
+
+### Task skills survive compaction and update in place
+
+- **Prompt-routed task skills now return after compaction.** The hook restores
+  the three most recently active task skills alongside the protected-floor
+  digest, so a short follow-up such as `continue` keeps the workflow and visual
+  verification rules that governed the work before context was compacted.
+- **A completed managed-skill sync refreshes active task rules on the next
+  prompt.** The hook compares the materialized generation on disk with its
+  per-session state, re-authorizes every restored name against the current
+  manifest, and injects the current bodies. A downgrade clears stale paid task
+  state; Prism-managed directories cannot use the user-owned local-skill
+  exception.
+- **User-owned local skills now route with their actual body.** A local
+  `SKILL.md` remains usable while signed out, while an entitled platform body
+  takes precedence if both sources use the same name.
+- **Codex hook context is anchored to the user's request.** Routed rules tell
+  the model to execute the preceding user request with the rules applied,
+  avoiding the trailing developer-context placement being mistaken for a new
+  task. The anchor and all restored content share the 9,800-character limit.
+- **Hook version 5 enforces its command version.** A still-running host with a
+  trusted v4 command cannot execute the rewritten v5 script. After upgrading,
+  run `prism connect --refresh --no-models`; Codex must trust both new v5 hook
+  entries in `/hooks`. Restart the host if it has not reloaded the new hook
+  definitions. Once v5 is active, later skill-body generations refresh on the
+  next prompt without another host restart.
+- State names are validated and bounded before they become CLI arguments, and
+  the two-call refresh paths fit inside the host's 15-second hook timeout.
+
 ## What's New in v20.18.0
 
 ### The protected floor rides the bootstrap — and survives compaction

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism-mcp-server",
-  "version": "20.18.0",
+  "version": "20.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism-mcp-server",
-      "version": "20.18.0",
+      "version": "20.18.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-mcp-server",
-  "version": "20.18.0",
+  "version": "20.18.1",
   "mcpName": "io.github.dcostenco/prism-coder",
   "description": "Persistent session memory for AI coding agents that never leaves your machine — including the on-device model that reasons over it. Restores your prior decisions, open TODOs, and changed files across sessions; adds associative recall of related past work, semantic drift detection, and local inference. Local-first by default. Works with Claude Code, Cursor, and Codex.",
   "module": "index.ts",

--- a/packages/prism-coder/package.json
+++ b/packages/prism-coder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-coder",
-  "version": "20.18.0",
+  "version": "20.18.1",
   "description": "Prism Coder — Local LLM fleet + MCP cognitive memory for AI agents. Wraps prism-mcp-server with the prism-coder brand CLI. Install once, run anywhere.",
   "type": "module",
   "bin": {

--- a/plugins/prism/.claude-plugin/plugin.json
+++ b/plugins/prism/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-coder",
   "description": "Your coding agent forgets everything between sessions. Prism gives it a memory that sticks: your decisions, open TODOs, and changed files, restored the moment you return. It goes past a notes store — associative recall surfaces related past work, drift detection catches a long session wandering off-goal, and an on-device model reasons over all of it. Local-only by default: your work and the model reading it never leave your machine.",
-  "version": "20.18.0",
+  "version": "20.18.1",
   "author": {
     "name": "Synalux",
     "email": "support@synalux.ai"

--- a/plugins/prism/.codex-plugin/plugin.json
+++ b/plugins/prism/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-coder",
-  "version": "20.18.0",
+  "version": "20.18.1",
   "description": "Your coding agent forgets everything between sessions. Prism gives it a memory that sticks: your decisions, open TODOs, and changed files, restored the moment you return. It goes past a notes store — associative recall surfaces related past work, drift detection catches a long session wandering off-goal, and an on-device model reasons over all of it. Local-only by default: your work and the model reading it never leave your machine.",
   "author": {
     "name": "Synalux"

--- a/plugins/prism/.mcp.json
+++ b/plugins/prism/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "prism-mcp-server@20.18.0"
+        "prism-mcp-server@20.18.1"
       ],
       "env": {
         "npm_config_ignore_scripts": "true"

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dcostenco/prism-coder",
     "source": "github"
   },
-  "version": "20.18.0",
+  "version": "20.18.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "prism-mcp-server",
-      "version": "20.18.0",
+      "version": "20.18.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -577,11 +577,46 @@ program
       const shaped = result.names.length > 0
         ? reshapeForInlineBudget(result, HOOK_INLINE_SAFE_CHARS, writeRouteOffload)
         : { text: '' };
-      const payload = JSON.stringify({ names: result.names, text: result.names.length > 0 ? shaped.text : '' });
+      const payload = JSON.stringify({
+        names: result.names,
+        alreadyLoaded: result.alreadyLoaded,
+        text: result.names.length > 0 ? shaped.text : '',
+      });
       await new Promise<void>((resolveWrite) => process.stdout.write(payload + '\n', () => resolveWrite()));
     } catch {
       // Never break the hook: an empty result is a routing miss, not an error.
       await new Promise<void>((resolveWrite) => process.stdout.write('{"names":[],"text":""}\n', () => resolveWrite()));
+    } finally {
+      try { await closeStorage(); } catch { /* exit anyway */ }
+      process.exit(0);
+    }
+  });
+
+// Re-inject the most recently active task skills after the host discards its
+// transcript, or immediately after a new managed manifest reaches disk. Names
+// are re-authorized against the cached manifest before any body is returned.
+program
+  .command('reinject-skills')
+  .description('Render previously active, still-entitled skills for the host hook.')
+  .requiredOption('--names <names>', 'Comma-separated skill names from the hook session state')
+  .option('--budget <chars>', 'Maximum inline characters', String(9_800))
+  .action(async (options: { names: string; budget?: string }) => {
+    try {
+      const names = options.names.split(',').map((name) => name.trim()).filter(Boolean);
+      const requestedBudget = Number.parseInt(options.budget ?? '', 10);
+      const { runNamedSkillRouteFromCache } = await import('./tools/ledgerHandlers.js');
+      const { reshapeForInlineBudget, HOOK_INLINE_SAFE_CHARS } = await import('./tools/promptRouteHandler.js');
+      const budget = Number.isFinite(requestedBudget)
+        ? Math.max(256, Math.min(HOOK_INLINE_SAFE_CHARS, requestedBudget))
+        : HOOK_INLINE_SAFE_CHARS;
+      const result = await runNamedSkillRouteFromCache(names);
+      const shaped = result.names.length > 0
+        ? reshapeForInlineBudget(result, budget, writeRouteOffload)
+        : { text: '' };
+      const payload = JSON.stringify({ ok: true, names: result.names, text: result.names.length > 0 ? shaped.text : '' });
+      await new Promise<void>((resolveWrite) => process.stdout.write(payload + '\n', () => resolveWrite()));
+    } catch {
+      await new Promise<void>((resolveWrite) => process.stdout.write('{"ok":false,"names":[],"text":""}\n', () => resolveWrite()));
     } finally {
       try { await closeStorage(); } catch { /* exit anyway */ }
       process.exit(0);

--- a/src/promptRouteHostHook.ts
+++ b/src/promptRouteHostHook.ts
@@ -41,7 +41,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 /** Bump to force the on-disk script to be rewritten on the next ensure. */
-export const PROMPT_ROUTE_HOOK_VERSION = "4";
+export const PROMPT_ROUTE_HOOK_VERSION = "5";
 /** SessionStart matcher: only the post-compaction fire carries the digest.
  *  The script re-checks `source` itself, so a host that ignores matchers on
  *  this event still injects nothing at startup/resume. */
@@ -54,7 +54,8 @@ const HOOK_DIR = "prism-route";
 const COMMAND_SIGNATURE = `${HOOK_DIR}/${SCRIPT_FILE}`;
 /**
  * The command registered in the host config carries the version as an
- * argument (the script ignores argv — it reads stdin). This is a SECURITY
+ * argument. The script reads stdin for the hook payload and rejects a stale
+ * version argument before executing routing logic. This is a SECURITY
  * property, found by an external probe of Codex 0.146: Codex's hook-trust
  * hash covers the CONFIGURED DEFINITION, not the file the command points at.
  * With a stable command and a version-refreshed script, every prism upgrade
@@ -97,13 +98,27 @@ import shutil
 import subprocess
 import sys
 
+INLINE_CONTEXT_CAP = 9800
+CLI_TIMEOUT_SECONDS = 6
+MAX_STATE_SKILLS = 500
+SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+TASK_CONTEXT_ANCHOR = (
+    "[Context attached to the user's request above. Do not acknowledge this context separately. "
+    "Execute the user's request now, applying the following task rules.]"
+)
+
+
+def content_cap():
+    return INLINE_CONTEXT_CAP - len(TASK_CONTEXT_ANCHOR) - 2
+
 
 def emit(extra=None, event="UserPromptSubmit"):
     out = {"continue": True, "suppressOutput": True}
     if extra:
+        anchored = TASK_CONTEXT_ANCHOR + "\\n\\n" + extra[:content_cap()]
         out["hookSpecificOutput"] = {
             "hookEventName": event,
-            "additionalContext": extra,
+            "additionalContext": anchored,
         }
     print(json.dumps(out))
 
@@ -116,7 +131,7 @@ def run_cli_json(cli, args, stdin_text=""):
             input=stdin_text,
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=CLI_TIMEOUT_SECONDS,
         )
     except Exception:
         return None
@@ -146,6 +161,70 @@ def session_state_path(payload):
     session = re.sub(r"[^A-Za-z0-9._-]", "_", session).lstrip(".")[:80] or "default"
     state_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "state")
     return state_dir, os.path.join(state_dir, session + ".json")
+
+
+def read_state(state_path):
+    try:
+        with open(state_path) as fh:
+            value = json.load(fh)
+    except Exception:
+        return {"generation": "", "names": []}
+    if isinstance(value, list):
+        return {"generation": "", "names": clean_names(value)}
+    if not isinstance(value, dict):
+        return {"generation": "", "names": []}
+    generation = value.get("generation") if isinstance(value.get("generation"), str) else ""
+    names = value.get("names") if isinstance(value.get("names"), list) else []
+    return {"generation": generation, "names": clean_names(names)}
+
+
+def clean_names(values):
+    kept = []
+    seen = set()
+    for value in values:
+        if not isinstance(value, str) or not SKILL_NAME_RE.fullmatch(value) or value in seen:
+            continue
+        kept.append(value)
+        seen.add(value)
+    return kept[-MAX_STATE_SKILLS:]
+
+
+def write_state(state_dir, state_path, generation, names):
+    temp_path = state_path + ".tmp-" + str(os.getpid())
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(temp_path, "w") as fh:
+            json.dump({"generation": generation, "names": names}, fh)
+        os.replace(temp_path, state_path)
+    except Exception:
+        try:
+            os.remove(temp_path)
+        except Exception:
+            pass
+
+
+def current_generation():
+    override = os.environ.get("PRISM_ROUTE_SKILLS_INDEX")
+    index_path = override or os.path.expanduser("~/.agents/skills/.prism-managed-skills.json")
+    try:
+        with open(index_path) as fh:
+            value = json.load(fh)
+        generation = value.get("generation") if isinstance(value, dict) else ""
+        return generation if isinstance(generation, str) else ""
+    except Exception:
+        return ""
+
+
+def reinject(cli, names, budget):
+    selected = names[-3:]
+    if not selected or budget < 256:
+        return {"ok": True, "names": [], "text": ""}
+    data = run_cli_json(cli, [
+        "reinject-skills", "--names", ",".join(selected), "--budget", str(budget)
+    ])
+    if not isinstance(data, dict) or data.get("ok") is not True:
+        return {"ok": False, "names": [], "text": ""}
+    return data
 
 
 def payload_field(payload, *keys):
@@ -178,24 +257,32 @@ def on_session_start(payload):
     if not source.startswith("compact"):
         emit(event="SessionStart")
         return
-    # The skills injected before compaction are gone with it; forget the
-    # dedupe list so the next matching prompt can bring them back.
     state_dir, state_path = session_state_path(payload)
-    try:
-        os.remove(state_path)
-    except Exception:
-        pass
+    state = read_state(state_path)
+    generation = current_generation()
     cli = find_cli()
     if not cli:
         emit(event="SessionStart")
         return
     data = run_cli_json(cli, ["floor-digest"])
-    text = (data or {}).get("text") or ""
-    names = [n for n in ((data or {}).get("names") or []) if isinstance(n, str)]
-    if not names or not isinstance(text, str) or not text:
-        emit(event="SessionStart")
-        return
-    emit(text, event="SessionStart")
+    raw_floor_text = (data or {}).get("text") or ""
+    floor_names = clean_names((data or {}).get("names") or [])
+    floor_text = raw_floor_text if floor_names and isinstance(raw_floor_text, str) else ""
+    remaining = content_cap() - len(floor_text) - (2 if floor_text else 0)
+    restored = reinject(cli, state["names"], remaining)
+    restored_names = clean_names(restored.get("names") or [])
+    restored_text = restored.get("text") if isinstance(restored.get("text"), str) else ""
+    # If the floor consumes the whole host budget or the CLI fails, keep the
+    # names but leave the generation stale so the next prompt retries. A
+    # successful empty result means the current entitlement revoked them.
+    if remaining < 256 and state["names"]:
+        write_state(state_dir, state_path, "", state["names"])
+    elif restored.get("ok") is not True:
+        write_state(state_dir, state_path, "", state["names"])
+    else:
+        write_state(state_dir, state_path, generation, restored_names)
+    combined = "\\n\\n".join(part for part in (floor_text, restored_text if restored_names else "") if part)
+    emit(combined[:content_cap()], event="SessionStart")
 
 
 def find_cli():
@@ -236,27 +323,59 @@ def main():
         or payload.get("user_prompt")
         or ""
     ).strip()
-    # Slash commands and micro-prompts ("ok", "merge") never route; skipping
-    # them keeps the common turn free.
-    if len(prompt) < 6 or prompt.startswith("/"):
+    state_dir, state_path = session_state_path(payload)
+    state = read_state(state_path)
+    loaded = state["names"]
+    generation = current_generation()
+    generation_changed = bool(loaded and generation and generation != state["generation"])
+
+    cli = find_cli()
+    if not cli:
+        emit()
+        return
+
+    # Slash commands never route. A micro-prompt normally stays free, but a
+    # just-materialized generation must replace any older task rules before
+    # even "continue" reaches the model.
+    if prompt.startswith("/"):
+        emit()
+        return
+    if len(prompt) < 6:
+        if generation_changed:
+            restored = reinject(cli, loaded, content_cap())
+            restored_names = clean_names(restored.get("names") or [])
+            restored_text = restored.get("text") if isinstance(restored.get("text"), str) else ""
+            if restored.get("ok") is True:
+                write_state(state_dir, state_path, generation, restored_names)
+            else:
+                write_state(state_dir, state_path, "", loaded)
+            if restored_names and restored_text:
+                emit(restored_text)
+                return
         emit()
         return
     # A pasted log can be megabytes; triggers live in the first human-sized
     # stretch, and the CLI caps identically on its side.
     prompt = prompt[:100_000]
 
-    state_dir, state_path = session_state_path(payload)
-    loaded = []
-    try:
-        with open(state_path) as fh:
-            data = json.load(fh)
-            if isinstance(data, list):
-                loaded = [n for n in data if isinstance(n, str)]
-    except Exception:
-        pass
-
-    cli = find_cli()
-    if not cli:
+    if generation_changed:
+        # Ask the normal matcher what this prompt needs, then rebuild one
+        # current-generation payload from the prior active set plus new hits.
+        # Emitting the matcher text directly would lose the old active rules
+        # whenever this prompt happened to match a different skill.
+        data = run_cli_json(cli, ["route-prompt", "--loaded", ""], prompt)
+        routed_names = clean_names((data or {}).get("names") or [])
+        active = [n for n in state["names"] if n not in routed_names] + routed_names
+        restored = reinject(cli, active, content_cap())
+        restored_names = clean_names(restored.get("names") or [])
+        restored_text = restored.get("text") if isinstance(restored.get("text"), str) else ""
+        if restored.get("ok") is True:
+            write_state(state_dir, state_path, generation, restored_names)
+        else:
+            write_state(state_dir, state_path, "", active)
+        if restored_names and restored_text:
+            emit(restored_text)
+            return
         emit()
         return
 
@@ -264,24 +383,27 @@ def main():
     if data is None:
         emit()
         return
-    names = [n for n in (data.get("names") or []) if isinstance(n, str)]
+    names = clean_names(data.get("names") or [])
     text = data.get("text") or ""
     if not names or not text:
+        touched = clean_names(data.get("alreadyLoaded") or [])
+        if touched and not generation_changed:
+            reordered = [n for n in loaded if n not in touched] + touched
+            write_state(state_dir, state_path, generation, reordered)
         emit()
         return
 
-    try:
-        os.makedirs(state_dir, exist_ok=True)
-        merged = loaded + [n for n in names if n not in loaded]
-        with open(state_path, "w") as fh:
-            json.dump(merged, fh)
-    except Exception:
-        pass  # dedupe degrades, injection still happens
+    touched = clean_names(data.get("alreadyLoaded") or [])
+    merged = [n for n in loaded if n not in touched and n not in names] + touched + names
+    write_state(state_dir, state_path, generation, clean_names(merged))
 
     emit(text)
 
 
 if __name__ == "__main__":
+    if "--v${PROMPT_ROUTE_HOOK_VERSION}" not in sys.argv[1:]:
+        print(json.dumps({"continue": True, "suppressOutput": True}))
+        sys.exit(0)
     try:
         main()
     except Exception:

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -2341,7 +2341,7 @@ export function buildSessionFactsLine(facts: Record<string, string | number | bo
  * only", never takes down startup.
  */
 export async function collectSkillTriggersOnThisMachine(): Promise<
-  { triggers: Record<string, string[]>; localNames: Set<string> } | undefined
+  { triggers: Record<string, string[]>; localNames: Set<string>; localBodies: Map<string, string> } | undefined
 > {
   try {
     const { collectScopedTriggers, collectLocalSkillTriggers } = await import("./scopedSkillTriggers.js");
@@ -2350,6 +2350,7 @@ export async function collectSkillTriggersOnThisMachine(): Promise<
     // __proto__/constructor must be a plain data key, not an inherited read.
     const merged: Record<string, string[]> = Object.create(null);
     const localNames = new Set<string>();
+    const localBodies = new Map<string, string>();
     const errors: Array<{ skill: string; reason: string }> = [];
 
     const settings = await getAllSettings();
@@ -2386,7 +2387,11 @@ export async function collectSkillTriggersOnThisMachine(): Promise<
       for (const [pattern, names] of Object.entries(local.triggers)) {
         (merged[pattern] ||= []).push(...names);
       }
-      for (const name of local.names) localNames.add(name);
+      for (const name of local.names) {
+        localNames.add(name);
+        const body = local.bodies.get(name);
+        if (body) localBodies.set(name, body);
+      }
       errors.push(...local.errors);
     } catch (error) {
       debugLog(`[skill-triggers] local scan skipped: ${error instanceof Error ? error.message : String(error)}`);
@@ -2397,7 +2402,7 @@ export async function collectSkillTriggersOnThisMachine(): Promise<
       // feature fixes — a skill that is installed and never fires.
       debugLog(`[skill-triggers] ignored trigger in "${error.skill}": ${error.reason}`);
     }
-    return Object.keys(merged).length > 0 ? { triggers: merged, localNames } : undefined;
+    return Object.keys(merged).length > 0 ? { triggers: merged, localNames, localBodies } : undefined;
   } catch (error) {
     debugLog(`[skill-triggers] collection failed: ${error instanceof Error ? error.message : String(error)}`);
     return undefined;
@@ -2450,6 +2455,42 @@ export async function runPromptRouteFromCache(prompt: string, loaded: string[]) 
       const v = Number(await getSetting("skill_manifest:routing_version", ""));
       return Number.isFinite(v) && v > 0 ? v : undefined;
     },
+  });
+}
+
+/**
+ * Rebuild task-specific hook context after compaction or a manifest update.
+ *
+ * The names came from this hook session's prior, entitlement-checked route.
+ * They still pass through the current cached entitlement set so a downgrade
+ * cannot resurrect a paid skill from stale hook state. This deliberately uses
+ * routePrompt's normal delivery and budget logic instead of reading native
+ * files in the host hook.
+ */
+export async function runNamedSkillRouteFromCache(names: string[]) {
+  const safeNames = [...new Set(names.filter((name) => NATIVE_SKILL_NAME.test(name)))];
+  if (safeNames.length === 0) {
+    return { names: [], alreadyLoaded: [], overflow: [], text: "No skills supplied — nothing to re-inject." };
+  }
+  const { routePrompt } = await import("./promptRouteHandler.js");
+  const { _setStorage } = await import("./skillRouting.js");
+  _setStorage(
+    async (key, value) => { await setSetting(key, value); },
+    async (key) => getSetting(key, ""),
+  );
+  return routePrompt("restore task-specific skills after compaction", [], {
+    resolvePromptSkillNames: async () => safeNames,
+    collectTriggers: collectSkillTriggersOnThisMachine,
+    entitledNames: async () => {
+      try {
+        const parsed: unknown = JSON.parse(await getSetting("skill_manifest:names", "[]"));
+        return new Set(Array.isArray(parsed) ? parsed.filter((name): name is string => typeof name === "string") : []);
+      } catch {
+        return new Set<string>();
+      }
+    },
+    getBody: (name: string) => getSetting(`skill:${name}`, ""),
+    manifestVersion: async () => undefined,
   });
 }
 

--- a/src/tools/promptRouteHandler.ts
+++ b/src/tools/promptRouteHandler.ts
@@ -55,7 +55,7 @@ export interface PromptRouteDeps {
   ) => Promise<string[]>;
   /** Delivered + local frontmatter triggers collected on this machine. */
   collectTriggers: () => Promise<
-    { triggers: Record<string, string[]>; localNames: Set<string> } | undefined
+    { triggers: Record<string, string[]>; localNames: Set<string>; localBodies?: Map<string, string> } | undefined
   >;
   /** Names this account is entitled to inject. */
   entitledNames: () => Promise<Set<string>>;
@@ -133,7 +133,13 @@ export async function routePrompt(
   const delivered: string[] = [];
   let budget = MAX_ROUTED_CHARS;
   for (const name of selected) {
-    const body = (await deps.getBody(name).catch(() => "")).trim();
+    // Select by the authorization source, not by which body happens to be
+    // non-empty. Otherwise an unentitled local same-name skill could expose a
+    // stale paid body left in the cache after a downgrade.
+    const platformAuthorized = entitled.has(name);
+    const body = (platformAuthorized
+      ? await deps.getBody(name).catch(() => "")
+      : scoped?.localBodies?.get(name) ?? "").trim();
     if (!body) {
       // Routed but undeliverable is the exact defect this feature exists to
       // surface. Say so rather than returning a name with nothing behind it.

--- a/src/tools/scopedSkillTriggers.ts
+++ b/src/tools/scopedSkillTriggers.ts
@@ -187,6 +187,10 @@ export function extractSkillTriggers(skillName: string, content: string): Trigge
  */
 const MAX_LOCAL_SKILLS = 300;
 const MAX_LOCAL_FILE_BYTES = 64 * 1024;
+const MANAGED_SKILL_MARKER = ".prism-managed.json";
+const MANAGED_SKILL_INDEX = ".prism-managed-skills.json";
+const MANAGED_SKILL_OWNER = "prism-skill-sync-v1";
+const LOCAL_SKILL_NAME = /^[a-z0-9][a-z0-9_-]{0,127}$/;
 
 export async function collectLocalSkillTriggers(
   roots: string[],
@@ -196,8 +200,13 @@ export async function collectLocalSkillTriggers(
     readFile: (path: string) => Promise<string>;
   },
   join: (...parts: string[]) => string,
-): Promise<TriggerExtraction & { names: string[] }> {
-  const merged: TriggerExtraction & { names: string[] } = { triggers: Object.create(null) as Record<string, string[]>, errors: [], names: [] };
+): Promise<TriggerExtraction & { names: string[]; bodies: Map<string, string> }> {
+  const merged: TriggerExtraction & { names: string[]; bodies: Map<string, string> } = {
+    triggers: Object.create(null) as Record<string, string[]>,
+    errors: [],
+    names: [],
+    bodies: new Map(),
+  };
   let budget = MAX_LOCAL_SKILLS;
   const seen = new Set<string>();
 
@@ -207,6 +216,19 @@ export async function collectLocalSkillTriggers(
       entries = await fs.readdir(root);
     } catch {
       continue;                                  // root absent — normal
+    }
+    const indexedManaged = new Set<string>();
+    try {
+      const index = JSON.parse(await fs.readFile(join(root, MANAGED_SKILL_INDEX))) as unknown;
+      if (index && typeof index === "object" && !Array.isArray(index)
+          && (index as { owner?: unknown }).owner === MANAGED_SKILL_OWNER
+          && Array.isArray((index as { skills?: unknown }).skills)) {
+        for (const value of (index as { skills: unknown[] }).skills) {
+          if (typeof value === "string" && LOCAL_SKILL_NAME.test(value)) indexedManaged.add(value);
+        }
+      }
+    } catch {
+      // A missing index is normal for a machine with user-owned skills only.
     }
     for (const name of entries) {
       if (budget-- <= 0) break;
@@ -219,7 +241,21 @@ export async function collectLocalSkillTriggers(
         if (!content.includes("prompt_triggers")) continue;
         seen.add(name);
         const extracted = extractSkillTriggers(name, content);
-        if (Object.keys(extracted.triggers).length > 0) merged.names.push(name);
+        let prismManaged = indexedManaged.has(name);
+        try {
+          const marker = JSON.parse(await fs.readFile(join(root, name, MANAGED_SKILL_MARKER))) as unknown;
+          prismManaged ||= Boolean(
+            marker && typeof marker === "object" && !Array.isArray(marker)
+              && (marker as { owner?: unknown }).owner === MANAGED_SKILL_OWNER,
+          );
+        } catch {
+          // No valid Prism marker means the directory is user-owned local
+          // content and remains eligible for the local entitlement exception.
+        }
+        if (Object.keys(extracted.triggers).length > 0 && !prismManaged) {
+          merged.names.push(name);
+          merged.bodies.set(name, content);
+        }
         for (const [pattern, names] of Object.entries(extracted.triggers)) {
           (merged.triggers[pattern] ||= []).push(...names);
         }

--- a/tests/prompt-route-host-hook.test.ts
+++ b/tests/prompt-route-host-hook.test.ts
@@ -102,6 +102,15 @@ describe("install", () => {
     expect(entry.hooks[0].additionalContextLimit).toBe(0);
   });
 
+  it("keeps two worst-case CLI waits inside the host hook timeout", () => {
+    ensurePromptRouteHook({ homeDir: home, env: {} });
+    const cfg = JSON.parse(readFileSync(join(home, ".codex", "hooks.json"), "utf8"));
+    const hostTimeout = cfg.hooks.UserPromptSubmit[0].hooks[0].timeout as number;
+    const cliTimeout = Number(PROMPT_ROUTE_HOOK_SCRIPT.match(/CLI_TIMEOUT_SECONDS = (\d+)/)?.[1]);
+    expect(cliTimeout).toBeGreaterThan(0);
+    expect(cliTimeout * 2).toBeLessThan(hostTimeout);
+  });
+
   it("claude registration does NOT carry the codex-only field — no unknown keys in settings.json", () => {
     ensurePromptRouteHook({ homeDir: home, env: {} });
     const entry = claudeConfig().hooks.UserPromptSubmit.find((e: unknown) => JSON.stringify(e).includes("prism-route"));
@@ -407,6 +416,7 @@ describe.skipIf(process.platform === "win32")("the hook script — never breaks 
   let hookDir: string;
   let script: string;
   let stub: string;
+  let skillIndex: string;
 
   beforeEach(() => {
     hookDir = join(home, ".claude", "hooks", "prism-route");
@@ -414,6 +424,8 @@ describe.skipIf(process.platform === "win32")("the hook script — never breaks 
     script = join(hookDir, "on_prompt.py");
     writeFileSync(script, PROMPT_ROUTE_HOOK_SCRIPT);
     chmodSync(script, 0o755);
+    skillIndex = join(home, "managed-skills.json");
+    writeFileSync(skillIndex, JSON.stringify({ generation: "generation-1" }));
     // Stub prism CLI: routes when --loaded is empty, dedupes when not;
     // answers floor-digest with a fixed digest; logs every invocation so a
     // test can assert the CLI was NOT called.
@@ -423,8 +435,16 @@ describe.skipIf(process.platform === "win32")("the hook script — never breaks 
       `#!/bin/bash
 echo "$1" >> "${join(home, "stub-calls.log")}"
 if [ "$1" = "floor-digest" ]; then echo '{"names":["prime-directive","ask-first"],"text":"Prism: context was compacted.\\n- floor line"}'; exit 0; fi
+if [ "$1" = "reinject-skills" ]; then
+  if [[ "$3" == *"task-flow-ui-ux-review"* ]]; then echo '{"ok":true,"names":["visual-screenshot-verification","task-flow-ui-ux-review"],"text":"BOTH CURRENT SKILL BODIES"}';
+  else echo '{"ok":true,"names":["visual-screenshot-verification"],"text":"SKILL BODY RESTORED"}'; fi
+  exit 0
+fi
 if [ "$1" != "route-prompt" ]; then echo '{"names":[],"text":""}'; exit 0; fi
-if [ "$3" = "" ]; then echo '{"names":["visual-screenshot-verification"],"text":"SKILL BODY HERE"}'; else echo '{"names":[],"text":""}'; fi
+prompt=$(cat)
+if [ "$3" = "" ] && [[ "$prompt" == *"totals are not sticky"* ]]; then echo '{"names":["visual-screenshot-verification"],"alreadyLoaded":[],"text":"SKILL BODY HERE"}';
+elif [ "$3" = "" ] && [[ "$prompt" == *"review the workflow"* ]]; then echo '{"names":["task-flow-ui-ux-review"],"alreadyLoaded":[],"text":"NEW SKILL BODY"}';
+else echo '{"names":[],"alreadyLoaded":["visual-screenshot-verification"],"text":""}'; fi
 `,
     );
     chmodSync(stub, 0o755);
@@ -433,12 +453,14 @@ if [ "$3" = "" ]; then echo '{"names":["visual-screenshot-verification"],"text":
     const log = join(home, "stub-calls.log");
     return existsSync(log) ? readFileSync(log, "utf8").trim().split("\n").filter(Boolean) : [];
   };
+  const routedContext = (out: ReturnType<typeof run>): string =>
+    out.hookSpecificOutput?.additionalContext ?? "";
 
   const run = (payload: unknown): { continue: boolean; suppressOutput?: boolean; hookSpecificOutput?: { hookEventName?: string; additionalContext?: string } } =>
     JSON.parse(
-      execFileSync("python3", [script], {
+      execFileSync("python3", [script, `--v${PROMPT_ROUTE_HOOK_VERSION}`], {
         input: JSON.stringify(payload),
-        env: { ...process.env, PRISM_ROUTE_CLI: stub },
+        env: { ...process.env, HOME: home, PRISM_ROUTE_CLI: stub, PRISM_ROUTE_SKILLS_INDEX: skillIndex },
         encoding: "utf8",
       }).trim(),
     );
@@ -446,15 +468,75 @@ if [ "$3" = "" ]; then echo '{"names":["visual-screenshot-verification"],"text":
   it("injects context on a routed prompt", () => {
     const out = run({ prompt: "the totals are not sticky", session_id: "s1" });
     expect(out.continue).toBe(true);
-    expect(out.hookSpecificOutput?.additionalContext).toBe("SKILL BODY HERE");
+    expect(routedContext(out)).toContain("Execute the user's request now");
+    expect(routedContext(out)).toMatch(/task rules\.\]\n\nSKILL BODY HERE$/);
+    expect(routedContext(out).length).toBeLessThanOrEqual(9_800);
+    expect(PROMPT_ROUTE_HOOK_SCRIPT).toContain("os.replace(temp_path, state_path)");
   });
 
   it("dedupes on the second prompt of the same session via its state file", () => {
     run({ prompt: "the totals are not sticky", session_id: "s2" });
     const state = JSON.parse(readFileSync(join(hookDir, "state", "s2.json"), "utf8"));
-    expect(state).toEqual(["visual-screenshot-verification"]);
+    expect(state).toEqual({ generation: "generation-1", names: ["visual-screenshot-verification"] });
     const out = run({ prompt: "the totals are not sticky", session_id: "s2" });
     expect(out.hookSpecificOutput).toBeUndefined();
+  });
+
+  it("re-injects updated task skills on continue after a new manifest generation — no host restart", () => {
+    run({ prompt: "the totals are not sticky", session_id: "s-generation" });
+    writeFileSync(skillIndex, JSON.stringify({ generation: "generation-2" }));
+    const out = run({ prompt: "continue", session_id: "s-generation" });
+    expect(routedContext(out)).toContain("Execute the user's request now");
+    expect(routedContext(out)).toMatch(/task rules\.\]\n\nSKILL BODY RESTORED$/);
+    expect(stubCalls()).toEqual(["route-prompt", "route-prompt", "reinject-skills"]);
+    expect(JSON.parse(readFileSync(join(hookDir, "state", "s-generation.json"), "utf8"))).toEqual({
+      generation: "generation-2",
+      names: ["visual-screenshot-verification"],
+    });
+  });
+
+  it("keeps prior active rules when a new generation prompt matches another skill", () => {
+    run({ prompt: "the totals are not sticky", session_id: "s-generation-new-hit" });
+    writeFileSync(skillIndex, JSON.stringify({ generation: "generation-2" }));
+    const out = run({ prompt: "review the workflow now", session_id: "s-generation-new-hit" });
+    expect(routedContext(out)).toMatch(/task rules\.\]\n\nBOTH CURRENT SKILL BODIES$/);
+    expect(JSON.parse(readFileSync(join(hookDir, "state", "s-generation-new-hit.json"), "utf8"))).toEqual({
+      generation: "generation-2",
+      names: ["visual-screenshot-verification", "task-flow-ui-ux-review"],
+    });
+  });
+
+  it("sanitizes and bounds persisted names before using them as CLI arguments", () => {
+    const stateDir = join(hookDir, "state");
+    mkdirSync(stateDir, { recursive: true });
+    const many = Array.from({ length: 510 }, (_, i) => `skill-${i}`);
+    writeFileSync(join(stateDir, "s-corrupt.json"), JSON.stringify({
+      generation: "old-generation",
+      names: ["../escape", "UPPER", ...many, "skill-509"],
+    }));
+    writeFileSync(stub, `#!/bin/bash
+if [ "$1" = "route-prompt" ]; then echo '{"names":[],"alreadyLoaded":[],"text":""}'; exit 0; fi
+if [ "$1" = "reinject-skills" ]; then printf '%s' "$3" > "${join(home, "reinject-names.log")}"; echo '{"ok":true,"names":[],"text":""}'; exit 0; fi
+echo '{"names":[],"text":""}'
+`);
+    chmodSync(stub, 0o755);
+    run({ prompt: "continue", session_id: "s-corrupt" });
+    const sent = readFileSync(join(home, "reinject-names.log"), "utf8").split(",");
+    expect(sent).toEqual(["skill-507", "skill-508", "skill-509"]);
+    expect(sent).not.toContain("../escape");
+    expect(sent).not.toContain("UPPER");
+  });
+
+  it("a stale trusted command cannot execute a rewritten hook body", () => {
+    const out = JSON.parse(
+      execFileSync("python3", [script, "--v4"], {
+        input: JSON.stringify({ prompt: "the totals are not sticky", session_id: "s-stale-command" }),
+        env: { ...process.env, HOME: home, PRISM_ROUTE_CLI: stub, PRISM_ROUTE_SKILLS_INDEX: skillIndex },
+        encoding: "utf8",
+      }).trim(),
+    );
+    expect(out).toEqual({ continue: true, suppressOutput: true });
+    expect(stubCalls()).toEqual([]);
   });
 
   it("passes through micro-prompts and slash commands without invoking the CLI", () => {
@@ -469,7 +551,7 @@ if [ "$3" = "" ]; then echo '{"names":["visual-screenshot-verification"],"text":
     // itself must then be launched by absolute path.
     const python3 = execFileSync("which", ["python3"], { encoding: "utf8" }).trim();
     const out = JSON.parse(
-      execFileSync(python3, [script], {
+      execFileSync(python3, [script, `--v${PROMPT_ROUTE_HOOK_VERSION}`], {
         input: JSON.stringify({ prompt: "the totals are not sticky" }),
         env: { ...process.env, PRISM_ROUTE_CLI: "/does/not/exist", PATH: "/nonexistent", HOME: home },
         encoding: "utf8",
@@ -485,7 +567,7 @@ echo '{"names":["visual-screenshot-verification"],"text":"BODY"}'
 `);
     chmodSync(stub, 0o755);
     const out = run({ prompt: "the totals are not sticky", session_id: "s9" });
-    expect(out.hookSpecificOutput?.additionalContext).toBe("BODY");
+    expect(routedContext(out)).toMatch(/task rules\.\]\n\nBODY$/);
   });
 
   describe("SessionStart — the floor comes back after a compaction, and only then", () => {
@@ -493,19 +575,135 @@ echo '{"names":["visual-screenshot-verification"],"text":"BODY"}'
       const out = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-compact" });
       expect(out.continue).toBe(true);
       expect(out.hookSpecificOutput?.hookEventName).toBe("SessionStart");
-      expect(out.hookSpecificOutput?.additionalContext).toBe("Prism: context was compacted.\n- floor line");
+      expect(routedContext(out)).toContain("Execute the user's request now");
+      expect(routedContext(out)).toMatch(/task rules\.\]\n\nPrism: context was compacted\.\n- floor line$/);
       expect(stubCalls()).toEqual(["floor-digest"]);
     });
 
-    it("forgets the session's dedupe list on compaction so the routed skills can come back", () => {
+    it("re-injects routed task skills during compaction so a following continue keeps the rules", () => {
       run({ prompt: "the totals are not sticky", session_id: "s-compact-2" });
       const state = join(hookDir, "state", "s-compact-2.json");
       expect(existsSync(state)).toBe(true);
-      run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-compact-2" });
-      expect(existsSync(state)).toBe(false);
-      // The next matching prompt routes again instead of being deduped away.
-      const out = run({ prompt: "the totals are not sticky", session_id: "s-compact-2" });
-      expect(out.hookSpecificOutput?.additionalContext).toBe("SKILL BODY HERE");
+      const compact = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-compact-2" });
+      expect(compact.hookSpecificOutput?.additionalContext).toContain("Prism: context was compacted.");
+      expect(compact.hookSpecificOutput?.additionalContext).toContain("SKILL BODY RESTORED");
+      expect(JSON.parse(readFileSync(state, "utf8"))).toEqual({
+        generation: "generation-1",
+        names: ["visual-screenshot-verification"],
+      });
+      const continued = run({ prompt: "continue", session_id: "s-compact-2" });
+      expect(continued.hookSpecificOutput).toBeUndefined();
+      expect(stubCalls()).toEqual(["route-prompt", "floor-digest", "reinject-skills", "route-prompt"]);
+    });
+
+    it("restores routed task skills when the floor digest is temporarily unavailable", () => {
+      run({ prompt: "the totals are not sticky", session_id: "s-compact-no-floor" });
+      writeFileSync(stub, `#!/bin/bash
+echo "$1" >> "${join(home, "stub-calls.log")}"
+if [ "$1" = "floor-digest" ]; then echo '{"names":[],"text":""}'; exit 0; fi
+if [ "$1" = "reinject-skills" ]; then echo '{"ok":true,"names":["visual-screenshot-verification"],"text":"TASK SURVIVED WITHOUT FLOOR"}'; exit 0; fi
+echo '{"names":[],"alreadyLoaded":[],"text":""}'
+`);
+      chmodSync(stub, 0o755);
+      const compact = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-compact-no-floor" });
+      expect(compact.hookSpecificOutput?.additionalContext).toContain("TASK SURVIVED WITHOUT FLOOR");
+      expect(JSON.parse(readFileSync(join(hookDir, "state", "s-compact-no-floor.json"), "utf8"))).toEqual({
+        generation: "generation-1",
+        names: ["visual-screenshot-verification"],
+      });
+      expect(stubCalls()).toEqual(["route-prompt", "floor-digest", "reinject-skills"]);
+    });
+
+    it("does not mark an older rendered body as current when generation changes during compaction", () => {
+      run({ prompt: "the totals are not sticky", session_id: "s-compact-race" });
+      writeFileSync(stub, `#!/bin/bash
+echo "$1" >> "${join(home, "stub-calls.log")}"
+if [ "$1" = "floor-digest" ]; then echo '{"names":["prime-directive"],"text":"GENERATION ONE FLOOR"}'; exit 0; fi
+if [ "$1" = "reinject-skills" ]; then
+  printf '%s' '{"generation":"generation-2"}' > "${skillIndex}"
+  echo '{"ok":true,"names":["visual-screenshot-verification"],"text":"GENERATION ONE BODY"}'
+  exit 0
+fi
+if [ "$1" = "route-prompt" ]; then echo '{"names":[],"alreadyLoaded":[],"text":""}'; exit 0; fi
+echo '{"names":[],"text":""}'
+`);
+      chmodSync(stub, 0o755);
+      const compact = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-compact-race" });
+      expect(routedContext(compact)).toContain("GENERATION ONE BODY");
+      expect(JSON.parse(readFileSync(join(hookDir, "state", "s-compact-race.json"), "utf8"))).toEqual({
+        generation: "generation-1",
+        names: ["visual-screenshot-verification"],
+      });
+      run({ prompt: "continue", session_id: "s-compact-race" });
+      expect(stubCalls()).toEqual(["route-prompt", "floor-digest", "reinject-skills", "route-prompt", "reinject-skills"]);
+    });
+
+    it("clears stale task state when the current entitlement no longer returns those skills", () => {
+      run({ prompt: "the totals are not sticky", session_id: "s-downgraded" });
+      writeFileSync(stub, `#!/bin/bash
+echo "$1" >> "${join(home, "stub-calls.log")}"
+if [ "$1" = "floor-digest" ]; then echo '{"names":["prism-startup"],"text":"FREE FLOOR"}'; else echo '{"ok":true,"names":[],"text":""}'; fi
+`);
+      chmodSync(stub, 0o755);
+      const out = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-downgraded" });
+      expect(routedContext(out)).toMatch(/task rules\.\]\n\nFREE FLOOR$/);
+      expect(JSON.parse(readFileSync(join(hookDir, "state", "s-downgraded.json"), "utf8"))).toEqual({
+        generation: "generation-1",
+        names: [],
+      });
+    });
+
+    it("keeps task names retryable when the floor leaves no safe body budget", () => {
+      run({ prompt: "the totals are not sticky", session_id: "s-floor-full" });
+      const floor = "F".repeat(9_700);
+      writeFileSync(stub, `#!/bin/bash
+echo "$1" >> "${join(home, "stub-calls.log")}"
+if [ "$1" = "floor-digest" ]; then printf '{"names":["prime-directive"],"text":"%s"}\\n' '${floor}'; else echo '{"names":[],"text":""}'; fi
+`);
+      chmodSync(stub, 0o755);
+      const out = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-floor-full" });
+      expect(routedContext(out)).toContain("Execute the user's request now");
+      expect(routedContext(out)).toHaveLength(9_800);
+      expect(JSON.parse(readFileSync(join(hookDir, "state", "s-floor-full.json"), "utf8"))).toEqual({
+        generation: "",
+        names: ["visual-screenshot-verification"],
+      });
+      expect(stubCalls()).toEqual(["route-prompt", "floor-digest"]);
+    });
+
+    it("keeps task names retryable when re-injection transport fails during compaction", () => {
+      run({ prompt: "the totals are not sticky", session_id: "s-compact-timeout" });
+      writeFileSync(stub, `#!/bin/bash
+echo "$1" >> "${join(home, "stub-calls.log")}"
+if [ "$1" = "floor-digest" ]; then echo '{"names":["prime-directive"],"text":"FREE FLOOR"}'; exit 0; fi
+if [ "$1" = "reinject-skills" ]; then echo '{"ok":false,"names":[],"text":""}'; exit 0; fi
+echo '{"names":[],"text":""}'
+`);
+      chmodSync(stub, 0o755);
+      const out = run({ hook_event_name: "SessionStart", source: "compact", session_id: "s-compact-timeout" });
+      expect(routedContext(out)).toMatch(/task rules\.\]\n\nFREE FLOOR$/);
+      expect(JSON.parse(readFileSync(join(hookDir, "state", "s-compact-timeout.json"), "utf8"))).toEqual({
+        generation: "",
+        names: ["visual-screenshot-verification"],
+      });
+    });
+
+    it("keeps task names retryable when re-injection fails after a manifest refresh", () => {
+      run({ prompt: "the totals are not sticky", session_id: "s-generation-timeout" });
+      writeFileSync(skillIndex, JSON.stringify({ generation: "generation-2" }));
+      writeFileSync(stub, `#!/bin/bash
+echo "$1" >> "${join(home, "stub-calls.log")}"
+if [ "$1" = "reinject-skills" ]; then echo '{"ok":false,"names":[],"text":""}'; exit 0; fi
+if [ "$1" = "route-prompt" ]; then echo '{"names":[],"alreadyLoaded":[],"text":""}'; exit 0; fi
+echo '{"names":[],"text":""}'
+`);
+      chmodSync(stub, 0o755);
+      const out = run({ prompt: "continue", session_id: "s-generation-timeout" });
+      expect(out.hookSpecificOutput).toBeUndefined();
+      expect(JSON.parse(readFileSync(join(hookDir, "state", "s-generation-timeout.json"), "utf8"))).toEqual({
+        generation: "",
+        names: ["visual-screenshot-verification"],
+      });
     });
 
     it.each(["startup", "resume", "clear", ""])("passes through on source=%j without invoking the CLI — the bootstrap already carries the digest", (source) => {
@@ -524,7 +722,7 @@ echo '{"names":["visual-screenshot-verification"],"text":"BODY"}'
     it("passes through when the CLI is missing or fails — a compaction must never break the session", () => {
       const python3 = execFileSync("which", ["python3"], { encoding: "utf8" }).trim();
       const out = JSON.parse(
-        execFileSync(python3, [script], {
+        execFileSync(python3, [script, `--v${PROMPT_ROUTE_HOOK_VERSION}`], {
           input: JSON.stringify({ hook_event_name: "SessionStart", source: "compact" }),
           env: { ...process.env, PRISM_ROUTE_CLI: "/does/not/exist", PATH: "/nonexistent", HOME: home },
           encoding: "utf8",
@@ -555,7 +753,7 @@ echo '{"names":["visual-screenshot-verification"],"text":"BODY"}'
     ])("recognises the compaction fire under alternative payload spellings: %j", (payload) => {
       const out = run({ ...payload, session_id: "s-alias" });
       expect(out.hookSpecificOutput?.hookEventName).toBe("SessionStart");
-      expect(out.hookSpecificOutput?.additionalContext).toBe("Prism: context was compacted.\n- floor line");
+      expect(routedContext(out)).toMatch(/task rules\.\]\n\nPrism: context was compacted\.\n- floor line$/);
       expect(stubCalls()).toEqual(["floor-digest"]);
     });
 
@@ -577,13 +775,13 @@ echo '{"names":["visual-screenshot-verification"],"text":"BODY"}'
 
     it("an aliased event that is NOT SessionStart still routes the prompt", () => {
       const out = run({ hookEventName: "UserPromptSubmit", prompt: "the totals are not sticky", session_id: "s-alias-prompt" });
-      expect(out.hookSpecificOutput?.additionalContext).toBe("SKILL BODY HERE");
+      expect(routedContext(out)).toMatch(/task rules\.\]\n\nSKILL BODY HERE$/);
     });
   });
 
   it("passes through on garbage stdin", () => {
     const out = JSON.parse(
-      execFileSync("python3", [script], {
+      execFileSync("python3", [script, `--v${PROMPT_ROUTE_HOOK_VERSION}`], {
         input: "not json at all",
         env: { ...process.env, PRISM_ROUTE_CLI: stub },
         encoding: "utf8",

--- a/tests/tools/ledgerHandlers.test.ts
+++ b/tests/tools/ledgerHandlers.test.ts
@@ -212,6 +212,7 @@ import { awaitSkillManifestSync, readNativeSkillBody } from "../../src/skillMani
 import { SKILL_DIGEST_UNAVAILABLE } from "../../src/utils/skillDigest.js";
 import {
   collectSkillTriggersOnThisMachine,
+  runNamedSkillRouteFromCache,
   sessionSaveLedgerHandler,
   sessionSaveHandoffHandler,
   sessionSaveExperienceHandler,
@@ -311,6 +312,28 @@ describe("ledgerHandlers", () => {
     mockGetAllSettings.mockResolvedValue({});
     mockRequireContextLoadedForProject.mockResolvedValue(null);
     mockRegisterContextLoaded.mockResolvedValue();
+  });
+
+  describe("runNamedSkillRouteFromCache", () => {
+    it("re-injects only names in the current entitlement manifest", async () => {
+      mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
+        "skill_manifest:names": JSON.stringify(["current-fixture"]),
+        "skill:current-fixture": "CURRENT BODY",
+        "skill:stale-paid-fixture": "STALE PAID BODY",
+      }[key] ?? fallback));
+      mockGetAllSettings.mockResolvedValue({});
+
+      const result = await runNamedSkillRouteFromCache([
+        "current-fixture",
+        "stale-paid-fixture",
+        "../unsafe",
+      ]);
+
+      expect(result.names).toEqual(["current-fixture"]);
+      expect(result.text).toContain("CURRENT BODY");
+      expect(result.text).not.toContain("STALE PAID BODY");
+      expect(result.text).not.toContain("../unsafe");
+    });
   });
 
   // ====================================================================

--- a/tests/tools/prompt-route.test.ts
+++ b/tests/tools/prompt-route.test.ts
@@ -109,6 +109,51 @@ describe("injection", () => {
     expect(r.names).toEqual(["ghost"]);
     expect(r.text).toMatch(/no content on this machine/i);
   });
+
+  it("injects a user-owned local body when no delivered cache body exists", async () => {
+    const r = await routePrompt("local workflow", [], deps({
+      resolvePromptSkillNames: async () => ["my-local"],
+      collectTriggers: async () => ({
+        triggers: { "\\blocal\\b": ["my-local"] },
+        localNames: new Set(["my-local"]),
+        localBodies: new Map([["my-local", "# my-local\nLOCAL BODY"]]),
+      }),
+      entitledNames: async () => new Set(),
+      getBody: async () => "",
+    }));
+    expect(r.names).toEqual(["my-local"]);
+    expect(r.text).toContain("LOCAL BODY");
+  });
+
+  it("does not let a same-name local file shadow a delivered platform body", async () => {
+    const r = await routePrompt("shared workflow", [], deps({
+      resolvePromptSkillNames: async () => ["shared-skill"],
+      collectTriggers: async () => ({
+        triggers: { "\\bshared\\b": ["shared-skill"] },
+        localNames: new Set(["shared-skill"]),
+        localBodies: new Map([["shared-skill", "LOCAL SHADOW"]]),
+      }),
+      entitledNames: async () => new Set(["shared-skill"]),
+      getBody: async () => "PLATFORM BODY",
+    }));
+    expect(r.text).toContain("PLATFORM BODY");
+    expect(r.text).not.toContain("LOCAL SHADOW");
+  });
+
+  it("does not expose a stale cached paid body through an unentitled same-name local skill", async () => {
+    const r = await routePrompt("shared workflow", [], deps({
+      resolvePromptSkillNames: async () => ["shared-skill"],
+      collectTriggers: async () => ({
+        triggers: { "\\bshared\\b": ["shared-skill"] },
+        localNames: new Set(["shared-skill"]),
+        localBodies: new Map([["shared-skill", "SAFE LOCAL BODY"]]),
+      }),
+      entitledNames: async () => new Set(),
+      getBody: async () => "STALE PAID BODY",
+    }));
+    expect(r.text).toContain("SAFE LOCAL BODY");
+    expect(r.text).not.toContain("STALE PAID BODY");
+  });
 });
 
 describe("host inline budget — hosts hard-cap hook context (Claude Code 10k chars, Codex ~2.5k tokens)", () => {
@@ -278,12 +323,16 @@ describe("entitlement and privacy", () => {
     // the entitlement filter would drop them without this bypass — the same
     // one session_bootstrap applies.
     const r = await routePrompt("ui/ux", [], deps({
-      resolvePromptSkillNames: async () => ["team-private-skill"],
+      resolvePromptSkillNames: async () => ["local-private-skill"],
       entitledNames: async () => new Set<string>(),
-      collectTriggers: async () => ({ triggers: {}, localNames: new Set(["team-private-skill"]) }),
+      collectTriggers: async () => ({
+        triggers: {},
+        localNames: new Set(["local-private-skill"]),
+        localBodies: new Map([["local-private-skill", "# local\nLocal body"]]),
+      }),
     }));
-    expect(r.names).toEqual(["team-private-skill"]);
-    expect(r.text).toContain("Account-scoped body");
+    expect(r.names).toEqual(["local-private-skill"]);
+    expect(r.text).toContain("Local body");
   });
 
   it("still routes when on-device trigger collection fails", async () => {

--- a/tests/tools/scoped-skill-triggers.test.ts
+++ b/tests/tools/scoped-skill-triggers.test.ts
@@ -265,6 +265,50 @@ describe("local-scope skills — written to disk, never in the settings cache", 
     // Without the name the caller's entitlement filter would drop the match,
     // since a local file is not in the delivery manifest.
     expect(result.names).toEqual(["my-local"]);
+    expect(result.bodies.get("my-local")).toContain("# my-local");
+  });
+
+  it("never labels a Prism-managed directory as user-owned local entitlement", async () => {
+    const body = `---\nname: paid-managed\ndescription: d\nprompt_triggers:\n  - "\\bmanaged\\b"\n---\n# paid`;
+    const result = await collectLocalSkillTriggers(
+      ["/root/.agents/skills"],
+      fakeFs({
+        "/root/.agents/skills/paid-managed/SKILL.md": body,
+        "/root/.agents/skills/paid-managed/.prism-managed.json": JSON.stringify({
+          owner: "prism-skill-sync-v1",
+          generation: "old-paid-generation",
+        }),
+      }),
+      join,
+    );
+    // Its trigger remains available to the matcher, but the current manifest
+    // must authorize it; stale managed files never get the local bypass.
+    expect(result.triggers["\\bmanaged\\b"]).toEqual(["paid-managed"]);
+    expect(result.names).toEqual([]);
+    expect(result.bodies.has("paid-managed")).toBe(false);
+  });
+
+  it("uses the managed index when a paid directory marker is missing or corrupt", async () => {
+    const body = `---\nname: paid-managed\ndescription: d\nprompt_triggers:\n  - "\\bmanaged\\b"\n---\n# paid`;
+    for (const marker of [undefined, "{corrupt"]) {
+      const files: Record<string, string> = {
+        "/root/.agents/skills/.prism-managed-skills.json": JSON.stringify({
+          owner: "prism-skill-sync-v1",
+          generation: "old-paid-generation",
+          skills: ["paid-managed"],
+        }),
+        "/root/.agents/skills/paid-managed/SKILL.md": body,
+      };
+      if (marker !== undefined) files["/root/.agents/skills/paid-managed/.prism-managed.json"] = marker;
+      const result = await collectLocalSkillTriggers(
+        ["/root/.agents/skills"],
+        fakeFs(files),
+        join,
+      );
+      expect(result.triggers["\\bmanaged\\b"]).toEqual(["paid-managed"]);
+      expect(result.names).toEqual([]);
+      expect(result.bodies.has("paid-managed")).toBe(false);
+    }
   });
 
   it("ignores skills without triggers, missing roots, and oversized files", async () => {
@@ -278,6 +322,7 @@ describe("local-scope skills — written to disk, never in the settings cache", 
     );
     expect(result.triggers).toEqual({});
     expect(result.names).toEqual([]);
+    expect(result.bodies.size).toBe(0);
   });
 
   it("does not count the same skill twice when both host roots mirror it", async () => {


### PR DESCRIPTION
A routed skill could disappear after host compaction or a manifest refresh, so later prompts such as “continue” could run without the task rules that governed the work. The hook now persists the current task-skill set, reauthorizes and restores the three most recently active skills after compaction or generation changes, and restores task rules independently when the protected-floor digest is temporarily unavailable.

The same path now preserves the entitlement boundary: Prism-managed files cannot use the user-owned local bypass, while actual local skills route from their on-disk bodies. Codex and Claude registrations use a versioned v5 command so Codex must trust the changed executable definition; Codex alone receives additionalContextLimit: 0.

Validation:
- npm run build
- npm test — 192 files passed, 3 skipped; 4,546 tests passed, 66 skipped
- focused routing/state/entitlement suite — 293 passed
- npm audit --audit-level=high — 0 vulnerabilities
- publish/private-content guards and implementation-integrity audit
- package dry run — 188 files, required runtime files present
- isolated built-CLI route and reinjection exercises for user-owned local and Prism-managed entitled skills
